### PR TITLE
Added persistent sessions to 'How to run ACCESS-CM' page

### DIFF
--- a/docs/js/miscellaneous.js
+++ b/docs/js/miscellaneous.js
@@ -62,7 +62,7 @@ function tabFunctionality() {
   document.querySelectorAll('[href^="#"]:not([class^="md"])').forEach(el => {
     let href = el.getAttribute('href');
     let tabEl = document.getElementById(href.slice(1,))
-    if (tabEl.parentElement.classList.contains("tabLabels")) {
+    if (tabEl?.parentElement.classList.contains("tabLabels")) {
       el.addEventListener("click",(e) => openTab(tabEl), false);
     }
   })

--- a/docs/models/run-a-model/run-access-cm.md
+++ b/docs/models/run-a-model/run-access-cm.md
@@ -1,5 +1,10 @@
 {% set model = "ACCESS-CM" %}
 # Run {{ model }}
+<div class="note">
+    <b>Important for <i>accessdev</i> users!</b>
+    <br>
+    If you are an <i>accessdev</i> user, make sure you are a member of <a href="https://my.nci.org.au/mancini/project/hr22/join" target="_blank">hr22</a> and <a href="https://my.nci.org.au/mancini/project/ki32/join" target="_blank">ki32</a> projects, and then check the new <a href="{{ '#setup-%s-persistent-session'%model.lower() }}">persistent session worflow for {{ model }}</a>, and how to <a href="#port-suites-from-accessdev">port suites from accessdev</a>.
+</div>
 ## Prerequisites
 ### General prerequisites
 Before running {{ model }}, you need to fulfil general prerequisites outlined in the <a href="/getting_started/first_steps">First Steps</a> section.
@@ -25,34 +30,29 @@ If you are unsure whether {{ model }} is the right choice for your experiment, t
         For more information on how to join specific NCI projects, refer to <a href="https://opus.nci.org.au/display/Help/How+to+connect+to+a+project" target="_blank">How to connect to a project</a>.
     </li>
     <li>
-    <b>Connection to an ARE VDI Desktop</b>
+    <b>Connection to an ARE VDI Desktop (optional)</b>
         <br>
-        To run {{ model }}, you need to be able to start an <a href="https://are.nci.org.au/pun/sys/dashboard/batch_connect/sys/desktop_vnc/ncigadi/session_contexts/new" target="_blank">Australian Research Environment (ARE) VDI Desktop</a> session.
+        To run {{ model }}, it is preferred to start an <a href="https://are.nci.org.au/pun/sys/dashboard/batch_connect/sys/desktop_vnc/ncigadi/session_contexts/new" target="_blank">Australian Research Environment (ARE) VDI Desktop</a> session.
         <br>
         If you are not familiar with ARE, check out the <a href="/getting_started/are">Getting Started on ARE</a> section.
     </li>
 </ul>
 
 --------------------------------------------
-## Setup ARE VDI Desktop
+## Setup ARE VDI Desktop (optional)
+To skip this step and run {{ model }} from <i>Gadi</i> login node instead, check <a href="{{ '#setup-%s-persistent-session'%model.lower() }}">Setup {{ model }} persistent session</a>.
+
 ### Launch ARE VDI Session
 Go to the <a href="https://are.nci.org.au/pun/sys/dashboard/batch_connect/sys/desktop_vnc/ncigadi/session_contexts/new" target="_blank">ARE VDI</a> page and launch a session with the following directives:
 <ul>
     <li>
-        <b>Walltime (hours)</b> &rarr; &thickapprox; <code>4</code> per simulated year.
+        <b>Walltime (hours)</b> &rarr; <code>2</code>
         <br>
-        With the current state of the ARE/Gadi workflow, <b>the ARE VDI session needs to remain active and running for the entirety of the {{ model }} simulation</b>. If the ARE VDI session expires before the end of the simulation, the simulation itself will be terminated as well.
+        This is the amount of time the ARE VDI session will stay active for.
         <br>
+        {{ model }} does not run directly on ARE.
         <br>
-        This means that <code>walltime</code> needs to be set according to the simulation length.
-        <br>
-        A good estimate to calculate the <code>walltime</code> needed is <b>4 hours per simulated year</b>.
-        <div class="note">
-            ARE VDI session cannot be spun up for more than 48 consecutive hours. This means that {{ model }} simulations that need more than 48 hours to complete, at the current state, need to be broken down into multiple chunks running for up to 48 hours.
-            <br>
-            <br>
-            In the near future this will not be necessary anymore, as there will be long running servers in place for runnning {{ model }} simulations.
-        </div>
+        This means that the ARE VDI session only needs to carry out setup steps as well as starting the run itself. All these tasks can be done within 2 hours.
     </li>
     <li>
         <b>Queue</b> &rarr; <code>normalbw</code>
@@ -60,9 +60,7 @@ Go to the <a href="https://are.nci.org.au/pun/sys/dashboard/batch_connect/sys/de
     <li>
         <b>Compute Size</b> &rarr; <code>tiny</code> (1 CPU)
         <br>
-        {{ model }} runs on a different Gadi node with respect to the one where the ARE VDI session is launched.
-        <br>
-        This means that the ARE VDI session only needs to carry out setup steps as well as starting the run itself. All these tasks can be easily done with only 1 CPU.
+        As said above, the ARE VDI session is only needed for setup and startup tasks, which can be easily done with only 1 CPU.
     </li>
     <li>
         <b>Project</b> &rarr; a project of which you are a member.
@@ -91,6 +89,78 @@ Once the new tab opens, you will see a Desktop with a few folders on the left.
 To open the terminal, click on the black terminal icon at the top of the window. You should now be connected to a <i>Gadi</i> computing node.
 <img src="/assets/run_access_cm/open_are_vdi_terminal.gif" alt="Open ARE VDI terminal" class="example-img" loading="lazy"/>
 
+## Setup {{ model }} persistent session
+To support the use of long-running processes (such as ACCESS models runs), NCI provides a service on <i>Gadi</i> called <a href="https://opus.nci.org.au/display/Help/Persistent+Sessions" target="_blank">persistent sessions</a>.
+
+To run {{ model }}, you need to start a persistent session and set it as the target session for the model run.
+
+### Start a new persistent session
+To start a new persistent session on <i>Gadi</i> (in a login node, or in an ARE terminal instance), run the following command:
+<pre><code>persistent-sessions start &lt;name&gt;</code></pre>
+
+This will start a persistent session with the given <code>name</code> that runs under your <a href="/getting_started/first_steps#change-default-project-on-gadi">default project</a>. 
+<br>
+If you want to assign a different project to the persistent session, use the option <code>-p</code>:
+<pre><code>persistent-sessions start -p &lt;project&gt; &lt;name&gt;</code></pre>
+
+<div class="note">
+    The project assigned to a persistent session does not have to be necessarily the same to the project used to run {{ model }} configuration, but needs to have allocated <i>Service Units</i> (SU).
+    <br>
+    For more information, check how to <a href="/getting_started/first_steps#join-relevant-nci-projects">Join relevant NCI projects</a>.
+</div>
+<terminal-window data="input">
+    <terminal-line>persistent-sessions start &lt;name&gt;</terminal-line>
+    <terminal-line data="output">session &lt;persistent-session-uuid&gt; running - connect using</terminal-line>
+    <terminal-line data="output">&emsp;ssh &lt;name&gt;.&lt;$USER&gt;.&lt;project&gt;.ps.gadi.nci.org.au</terminal-line>
+</terminal-window>
+
+To list all the active persistent sessions run:
+<pre><code>persistent-sessions list</code></pre>
+
+<terminal-window data="input">
+    <terminal-line>persistent-sessions list</terminal-line>
+    <terminal-line data="output">&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&ensp;UUID&emsp;&emsp;PROJECT&emsp;&ensp;&ensp;ADDRESS&emsp;&emsp;&emsp;&emsp;CPUTIME&emsp;MEMORY</terminal-line>
+    <terminal-line data="output">&lt;persistent-session-uuid&gt;&emsp;&lt;project&gt;&emsp;10.9.0.62&emsp;00:00:05.213&emsp;30.5M</terminal-line>
+</terminal-window>
+
+
+The full name of a newly created persistent session is formatted as: 
+<br>
+<code>&lt;name&gt;.&lt;$USER&gt;.&lt;project&gt;.ps.gadi.nci.org.au</code>.
+
+### Specify {{ model }} target persistent session
+
+After starting the persistent session, it is essential to assign it to the {{ model }} run.
+<br>
+The easiest way to do so, is to insert the persistent session full name into the file <code>~/.persistent-sessions/cylc-session</code>.
+<br>
+You can do it manually, or by running the following command:
+
+<pre><code>cat > ~/.persistent-sessions/cylc-session <<< &lt;name&gt;.&lt;$USER&gt;.&lt;project&gt;.ps.gadi.nci.org.au</code></pre>
+
+For example, if the user <code>dm5220</code> started a persistent session named <code>cylc</code>, under the project <code>tm70</code>, the command will be:
+
+<terminal-window data="input">
+    <terminal-line>cat > ~/.persistent-sessions/cylc-session <<< cylc.dm5220.tm70.ps.gadi.nci.org.au</terminal-line>
+    <terminal-line data="input" linedelay="1000">cat ~/.persistent-sessions/cylc-session</terminal-line>
+    <terminal-line data="output">cylc.dm5220.tm70.ps.gadi.nci.org.au</terminal-line>
+</terminal-window>
+
+For more information on how to specify the target session, check <a href="https://opus.nci.org.au/display/DAE/Run+Cylc7+Suites#RunCylc7Suites-SpecifyTargetSession" target="_blank">Specify Target Session on Cylc7 Suites</a>.
+<div class="note">
+    You can concurrently submit multiple {{ model }} runs using the same persistent session, without the need to start another one. Therefore, the process of specifying the target persistent session for {{ model }} can potentially be done only once.
+    <br>
+    After specifying the {{ model }} target persistent session the first time, to run {{ model }} you just have to make sure to have an active persistent session named like the {{ model }} target persistent session.
+</div>
+
+### Terminate a persistent session
+To stop a persistent session, run:
+<pre><code>persistent-sessions kill &lt;persistent-session-uuid&gt;</code></pre>
+<div class="note">
+    When you terminate a persistent session, any model running on that session will stop. Therefore, you should check whether you have any active model runs before terminating a persistent session.
+</div>
+
+
 ## Get {{ model }} suite
 {{ model }} comprises the model components <a href="../../model_components/atmosphere/#unified-model-um">UM</a>, <a href="../../model_components/ocean/#modular-ocean-model-mom">MOM</a>, <a href="../../model_components/sea-ice/#cice">CICE</a>, <a href="../../model_components/land/#cable">CABLE</a> and <a href="../../model_components/coupler/#oasis3-mct">OASIS</a>. These components, which have different model parameters, input data and computer-related information, need to be packaged together as a <i>suite</i> in order to run.
 <br>
@@ -99,7 +169,6 @@ Each {{ model }} suite has a <code>suite-ID</code> in the format <code>u-&lt;sui
 For this example you can use <code>u-cy339</code>, which is a preindustrial experiment suite.
 <br>
 Typically, an existing suite is copied and then edited as needed for a particular run.
-
 
 ### Copy {{ model }} suite with Rosie
 <a href = "http://metomi.github.io/rose/doc/html/tutorial/rose/rosie.html" target="_blank">Rosie</a> is an <a href = "https://subversion.apache.org/" target="_blank">SVN</a> repository wrapper with a set of options specific for {{ model }} suites.
@@ -111,14 +180,21 @@ To copy an existing suite on <i>Gadi</i> you need to follow three main steps:
         <br>
         To get the Cylc7 setup required to run {{ model }}, execute the following commands:
         <pre><code>module use /g/data/hr22/modulefiles
-module load cylc7</code></pre>
+module load cylc7/23.09</code></pre>
         <terminal-window data="input">
             <terminal-line>module use /g/data/hr22/modulefiles</terminal-line>
-            <terminal-line>module load cylc7</terminal-line>
-            <terminal-line data="output">Loading cylc7/23.03</terminal-line>
+            <terminal-line>module load cylc7/23.09</terminal-line>
+            <terminal-line data="output">Using the cylc session &lt;name&gt;.&lt;$USER&gt;.&lt;project&gt;.ps.gadi.nci.org.au</terminal-line>
+            <terminal-line data="output"></terminal-line>
+            <terminal-line data="output">Loading cylc7/23.09</terminal-line>
             <terminal-line data="output">&emsp;Loading requirement: mosrs-setup/1.0.1</terminal-line>
         </terminal-window>
     </li>
+    <div class="note">
+        Make sure to load a version of <i>Cylc</i> >= <code>23.09</code>, as earlier versions do not support the persistent sessions workflow.
+        <br>
+        Also, before loading the <i>Cylc</i> module, make sure to have started a persistent session and to have assigned it to the {{ model }} workflow. For more information about these steps, check <a href="{{ '#setup-%s-persistent-session'%model.lower() }}">Setup {{ model }} persistent session</a>.
+    </div>
     <li>
         <b>MOSRS authentication</b>
         <br>
@@ -274,34 +350,39 @@ After the initial tasks are executed, the <i>Cylc</i> GUI will open. You can now
     <terminal-line>[INFO] create: share/cycle</terminal-line>
     <terminal-line>[INFO] create: work</terminal-line>
     <terminal-line>[INFO] chdir: log/</terminal-line>
-    <terminal-line>[INFO] &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;&thinsp;._.</terminal-line>
+    <terminal-line>[WARN] Using the cylc session &lt;persistent-session-full-name&gt;</terminal-line>
+    <terminal-line>[WARN]</terminal-line>
+    <terminal-line>[WARN] Loading cylc7/23.09</terminal-line>
+    <terminal-line>[WARN] &emsp;Loading requirement: mosrs-setup/1.0.1</terminal-line>
+    <terminal-line>[INFO] &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;&thinsp;.&UnderBar;.</terminal-line>
     <terminal-line>[INFO] &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;&thinsp;| |&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;The Cylc Suite Engine [7.9.7]</terminal-line>
-    <terminal-line>[INFO] ._____._. ._| |_____.&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;Copyright (C) 2008-2019 NIWA</terminal-line>
-    <terminal-line>[INFO] | .___| | | | | .___|&emsp;& British Crown (Met Office) & Contributors.</terminal-line>
-    <terminal-line>[INFO] | !___| !_! | | !___. _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _</terminal-line>
-    <terminal-line>[INFO] !_____!___. |_!_____! This program comes with ABSOLUTELY NO WARRANTY;</terminal-line>
-    <terminal-line>[INFO] &emsp;&emsp;&emsp;&thinsp;.___! | &emsp;&emsp;&emsp;&emsp;&emsp;see `cylc warranty`. &thinsp;It is free software, you</terminal-line>
-    <terminal-line>[INFO] &emsp;&emsp;&emsp;&thinsp;!_____! &emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;are welcome to redistribute it under certain</terminal-line>
+    <terminal-line>[INFO] .&UnderBar;&UnderBar;&UnderBar;&UnderBar;&UnderBar;.&UnderBar;. .&UnderBar;| |&UnderBar;&UnderBar;&UnderBar;&UnderBar;&UnderBar;.&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;Copyright (C) 2008-2019 NIWA</terminal-line>
+    <terminal-line>[INFO] | .&UnderBar;&UnderBar;&UnderBar;| | | | | .&UnderBar;&UnderBar;&UnderBar;|&emsp;& British Crown (Met Office) & Contributors.</terminal-line>
+    <terminal-line>[INFO] | !&UnderBar;&UnderBar;&UnderBar;| !&UnderBar;! | | !&UnderBar;&UnderBar;&UnderBar;. &UnderBar; &UnderBar; &UnderBar; &UnderBar; &UnderBar; &UnderBar; &UnderBar; &UnderBar; &UnderBar; &UnderBar; &UnderBar; &UnderBar; &UnderBar; &UnderBar; &UnderBar; &UnderBar; &UnderBar; &UnderBar; &UnderBar; &UnderBar; &UnderBar; &UnderBar; &UnderBar; &UnderBar;</terminal-line>
+    <terminal-line>[INFO] !&UnderBar;&UnderBar;&UnderBar;&UnderBar;&UnderBar;!&UnderBar;&UnderBar;&UnderBar;. |&UnderBar;!&UnderBar;&UnderBar;&UnderBar;&UnderBar;&UnderBar;! This program comes with ABSOLUTELY NO WARRANTY;</terminal-line>
+    <terminal-line>[INFO] &emsp;&emsp;&emsp;&thinsp;.&UnderBar;&UnderBar;&UnderBar;! | &emsp;&emsp;&emsp;&emsp;&emsp;see `cylc warranty`. &thinsp;It is free software, you</terminal-line>
+    <terminal-line>[INFO] &emsp;&emsp;&emsp;&thinsp;!&UnderBar;&UnderBar;&UnderBar;&UnderBar;&UnderBar;! &emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;are welcome to redistribute it under certain</terminal-line>
     <terminal-line>[INFO]</terminal-line>
-    <terminal-line>[INFO] *** listening on https://&lt;gadi-cpu&gt;.gadi.nci.org.au:&lt;port&gt;/ ***</terminal-line>
+    <terminal-line>[INFO] *** listening on https://&lt;persistent-session-full-name&gt;:&lt;port&gt;/ ***</terminal-line>
     <terminal-line>[INFO]</terminal-line>
     <terminal-line>[INFO] To view suite server program contact information:</terminal-line>
     <terminal-line>[INFO]  $ cylc get-suite-contact &lt;suite-ID&gt;</terminal-line>
     <terminal-line>[INFO]</terminal-line>
     <terminal-line>[INFO] Other ways to see if the suite is still running:</terminal-line>
-    <terminal-line>[INFO]  $ cylc scan -n '&lt;suite-ID&gt;' &lt;gadi-cpu&gt;.gadi.nci.org.au</terminal-line>
-    <terminal-line>[INFO]  $ cylc ping -v --host=&lt;gadi-cpu&gt;.nci.org.au &lt;suite-ID&gt;</terminal-line>
-    <terminal-line>[INFO]  $ ps -opid,args &lt;PID&gt;  # on &lt;gadi-cpu&gt;.nci.org.au</terminal-line>
-    <img src="/assets/run_access_cm/Cylc_GUI_are.png" alt="Cylc GUI" imageTime="inf" loading="lazy">
+    <terminal-line>[INFO]  $ cylc scan -n '&lt;suite-ID&gt;' &lt;persistent-session-full-name&gt;</terminal-line>
+    <terminal-line>[INFO]  $ cylc ping -v --host=&lt;persistent-session-full-name&gt; &lt;suite-ID&gt;</terminal-line>
+    <terminal-line>[INFO]  $ ps -opid,args &lt;PID&gt;  # on &lt;persistent-session-full-name&gt;</terminal-line>
+    <img src="/assets/run&UnderBar;access_cm/Cylc_GUI_are.png" alt="Cylc GUI" imageTime="inf" loading="lazy"> -->
 </terminal-window>
+
 <div class="note">
     After running the command <code>rose suite-run</code>, if you get an error similar to the following:
     <pre><code><span style="color: orangered">[FAIL]</span> Suite "&lt;suite-ID&gt;" appears to be running:
 <span style="color: orangered">[FAIL]</span> Contact info from: "/home/565/&lt;$USER&gt;/cylc-run/&lt;suite-ID&gt;/.service/contact"
-<span style="color: orangered">[FAIL]</span>    CYLC_SUITE_HOST=gadi.nci.org.au
+<span style="color: orangered">[FAIL]</span>    CYLC_SUITE_HOST=&lt;persistent-session-full-name&gt;
 <span style="color: orangered">[FAIL]</span>    CYLC_SUITE_OWNER=&lt;$USER&gt;
 <span style="color: orangered">[FAIL]</span>    CYLC_SUITE_PORT=&lt;port&gt;
-<span style="color: orangered">[FAIL]</span>    CYLC_SUITE_PROCESS=&lt;PID&gt; python2 /usr/local/cylc/cylc-7.8.3/bin/cylc-run &lt;suite-ID&gt;
+<span style="color: orangered">[FAIL]</span>    CYLC_SUITE_PROCESS=&lt;PID&gt; /g/data/hr22/apps/cylc7/bin/python -s /g/data/hr22/apps/cylc7/cylc_7.9.7/bin/cylc-run &lt;suite-ID&gt; --host=localhost
 <span style="color: orangered">[FAIL]</span> Try "cylc stop '&lt;suite-ID&gt;'" first?</code></pre>
         you should run:
         <pre><code>rm /home/565/&lt;$USER&gt;/cylc-run/&lt;suite-ID&gt;/.service/contact</code></pre>
@@ -429,6 +510,10 @@ There are two main ways to restart a suite:
             <terminal-line>[INFO] delete: log/rose-suite-run.version</terminal-line>
             <terminal-line>[INFO] symlink: rose-conf/&lt;timestamp&gt;-restart.version <= log/rose-suite-run.version</terminal-line>
             <terminal-line>[INFO] chdir: log/</terminal-line>
+            <terminal-line>[WARN] Using the cylc session &lt;persistent-session-full-name&gt;</terminal-line>
+            <terminal-line>[WARN]</terminal-line>
+            <terminal-line>[WARN] Loading cylc7/23.09</terminal-line>
+            <terminal-line>[WARN] &emsp;Loading requirement: mosrs-setup/1.0.1</terminal-line>
             <terminal-line>[INFO] &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;&thinsp;._.</terminal-line>
             <terminal-line>[INFO] &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;&thinsp;| |&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;The Cylc Suite Engine [7.9.7]</terminal-line>
             <terminal-line>[INFO] ._____._. ._| |_____.&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;Copyright (C) 2008-2019 NIWA</terminal-line>
@@ -438,15 +523,15 @@ There are two main ways to restart a suite:
             <terminal-line>[INFO] &emsp;&emsp;&emsp;&thinsp;.___! | &emsp;&emsp;&emsp;&emsp;&emsp;see `cylc warranty`. &thinsp;It is free software, you</terminal-line>
             <terminal-line>[INFO] &emsp;&emsp;&emsp;&thinsp;!_____! &emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;are welcome to redistribute it under certain</terminal-line>
             <terminal-line>[INFO]</terminal-line>
-            <terminal-line>[INFO] *** listening on https://&lt;gadi-cpu&gt;.nci.org.au:&lt;port&gt;/ ***</terminal-line>
+            <terminal-line>[INFO] *** listening on https://&lt;persistent-session-full-name&gt;:&lt;port&gt;/ ***</terminal-line>
             <terminal-line>[INFO]</terminal-line>
             <terminal-line>[INFO] To view suite server program contact information:</terminal-line>
             <terminal-line>[INFO]  $ cylc get-suite-contact &lt;suite-ID&gt;</terminal-line>
             <terminal-line>[INFO]</terminal-line>
             <terminal-line>[INFO] Other ways to see if the suite is still running:</terminal-line>
-            <terminal-line>[INFO]  $ cylc scan -n '&lt;suite-ID&gt;' &lt;gadi-cpu&gt;.nci.org.au</terminal-line>
-            <terminal-line>[INFO]  $ cylc ping -v --host=&lt;gadi-cpu&gt;.nci.org.au &lt;suite-ID&gt;</terminal-line>
-            <terminal-line>[INFO]  $ ps -opid,args &lt;PID&gt;  # on &lt;gadi-cpu&gt;.nci.org.au</terminal-line>
+            <terminal-line>[INFO]  $ cylc scan -n '&lt;suite-ID&gt;' &lt;persistent-session-full-name&gt;</terminal-line>
+            <terminal-line>[INFO]  $ cylc ping -v --host=&lt;persistent-session-full-name&gt; &lt;suite-ID&gt;</terminal-line>
+            <terminal-line>[INFO]  $ ps -opid,args &lt;PID&gt;  # on &lt;persistent-session-full-name&gt;</terminal-line>
             <img src="/assets/run_access_cm/Cylc_GUI_are.png" alt="Cylc GUI" imageTime="inf" loading="lazy">
         </terminal-window>
     </li>
@@ -526,6 +611,52 @@ For the <code>u-cy339</code> suite in this example, the <code>atm</code> directo
 
 Files formatted as <code>&lt;suite-name&gt;a.xhist-&lt;year&gt;&lt;month&gt;&lt;day&gt;</code> contain metadata information.
 
+## Port suites from accessdev
+<i>accessdev</i> was the server used for {{ model }} run submission workflow before the update to persistent sessions.
+<br>
+If you have a suite that was running on <i>accessdev</i>, you can run it on persistent sessions by doing the following steps:
+
+<ol>
+    <li>
+        <b>Initialisation step</b>
+        <br>
+        To set the correct SSH configuration for <i>Cylc</i>, some SSH keys need to be created in the <code>~/.ssh</code> directory.
+        <br>
+        To create the needed SSH keys, run the following command:
+        <pre><code>/g/data/hr22/bin/gadi-cylc-setup-ps -y</code></pre>
+        <div class="note">
+            You only need to run this initialisation step once.
+        </div>
+    </li>
+    <li>
+        <b>Set host to localhost</b>
+        <br>
+        To enable <i>Cylc</i> to submit PBS jobs directly from the persistent session, the suite configuration should have its <code>host</code> set as <code>localhost</code>.
+        <br>
+        You can manually set all occurrencies of <code>host</code> to <code>localhost</code> in the suite configuration files. 
+        <br>
+        Alternatively, you can run the following command in the suite folder:
+        <pre><code>grep -rl --exclude-dir=.svn "host\s*=" . | xargs sed -i 's/\(host\s*=\s*\).*/\1localhost/g'</code></pre>
+    </li>
+    <li>
+        <b>Add gdata/hr22 and gdata/ki32 in the PBS storage directives</b>
+        <br>
+        The persistent sessions workflow uses files in the <code>hr22</code> and <code>ki32</code> project folders on <i>Gadi</i>. 
+        <br>
+        Therefore, the respective folders need to be added to the <code>storage</code> directive in the suite configuration files.
+        <br>
+        You can do this manually, or run the following command in the suite folder:
+        <pre><code>grep -rl --exclude-dir=.svn "\-l\s*storage\s*=" . | xargs sed -i '/\-l\s*storage\s*=\s*.*gdata\/hr22.*/! s/\(\-l\s*storage\s*=\s*.*\)/\1+gdata\/hr22/g ; /\-l\s*storage\s*=\s*.*gdata\/ki32.*/! s/\(\-l\s*storage\s*=\s*.*\)/\1+gdata\/ki32/g'</code></pre>
+    </li>
+</ol>
+
+
+<div class="note">
+    Some suites might not be ported this way. 
+    <br>
+    If you have a suite that was running on <i>accessdev</i> and, even after following the steps above, the run submission fails, consider <a href="/about/user_support/ask_on_forum">getting help on the Hive Forum</a>.
+</div>
+
 <br>
 <h6>References</h6>
 <ul class="references">
@@ -542,6 +673,9 @@ Files formatted as <code>&lt;suite-name&gt;a.xhist-&lt;year&gt;&lt;month&gt;&lt;
         <a href = "https://code.metoffice.gov.uk/doc/um/latest/um-training/rose-gui.html" target="_blank">https://code.metoffice.gov.uk/doc/um/latest/um-training/rose-gui.html</a>
     </li>
     <li>
-        <a href = "https://opus.nci.org.au/display/DAE/Cylc+7+on+ARE" target="_blank">https://opus.nci.org.au/display/DAE/Cylc+7+on+ARE</a>
+        <a href = "https://opus.nci.org.au/display/DAE/Run+Cylc7+Suites" target="_blank">https://opus.nci.org.au/display/DAE/Run+Cylc7+Suites</a>
+    </li>
+    <li>
+        <a href = "https://opus.nci.org.au/display/Help/Persistent+Sessions" target="_blank">https://opus.nci.org.au/display/Help/Persistent+Sessions</a>
     </li>
 </ul>

--- a/docs/models/run-a-model/run-access-cm.md
+++ b/docs/models/run-a-model/run-access-cm.md
@@ -3,7 +3,9 @@
 <div class="note">
     <b>Important for <i>accessdev</i> users!</b>
     <br>
-    If you are an <i>accessdev</i> user, make sure you are a member of <a href="https://my.nci.org.au/mancini/project/hr22/join" target="_blank">hr22</a> and <a href="https://my.nci.org.au/mancini/project/ki32/join" target="_blank">ki32</a> projects, and then check the new <a href="{{ '#setup-%s-persistent-session'%model.lower() }}">persistent session worflow for {{ model }}</a>, and how to <a href="#port-suites-from-accessdev">port suites from accessdev</a>.
+    If you are an <i>accessdev</i> user, make sure you are a member of <a href="https://my.nci.org.au/mancini/project/hr22/join" target="_blank">hr22</a> and <a href="https://my.nci.org.au/mancini/project/ki32/join" target="_blank">ki32</a> projects.
+    <br>
+    Then, refer to instructions on how to <a href="{{ '#set-up-%s-persistent-session'%model.lower() }}">set up persistent session worflow for {{ model }}</a>, and how to <a href="#port-suites-from-accessdev">port suites from accessdev</a>.
 </div>
 ## Prerequisites
 ### General prerequisites
@@ -32,18 +34,18 @@ If you are unsure whether {{ model }} is the right choice for your experiment, t
     <li>
     <b>Connection to an ARE VDI Desktop (optional)</b>
         <br>
-        To run {{ model }}, it is preferred to start an <a href="https://are.nci.org.au/pun/sys/dashboard/batch_connect/sys/desktop_vnc/ncigadi/session_contexts/new" target="_blank">Australian Research Environment (ARE) VDI Desktop</a> session.
+        To run {{ model }}, start an <a href="https://are.nci.org.au/pun/sys/dashboard/batch_connect/sys/desktop_vnc/ncigadi/session_contexts/new" target="_blank">Australian Research Environment (ARE) VDI Desktop</a> session.
         <br>
         If you are not familiar with ARE, check out the <a href="/getting_started/are">Getting Started on ARE</a> section.
     </li>
 </ul>
 
 --------------------------------------------
-## Setup ARE VDI Desktop (optional)
-To skip this step and run {{ model }} from <i>Gadi</i> login node instead, check <a href="{{ '#setup-%s-persistent-session'%model.lower() }}">Setup {{ model }} persistent session</a>.
+## Set up an ARE VDI Desktop (optional)
+To skip this step and instead run {{ model }} from <i>Gadi</i> login node, refer to instructions on how to <a href="{{ '#set-up-%s-persistent-session'%model.lower() }}">set up {{ model }} persistent session</a>.
 
 ### Launch ARE VDI Session
-Go to the <a href="https://are.nci.org.au/pun/sys/dashboard/batch_connect/sys/desktop_vnc/ncigadi/session_contexts/new" target="_blank">ARE VDI</a> page and launch a session with the following directives:
+Go to the <a href="https://are.nci.org.au/pun/sys/dashboard/batch_connect/sys/desktop_vnc/ncigadi/session_contexts/new" target="_blank">ARE VDI</a> page and launch a session with the following entries:
 <ul>
     <li>
         <b>Walltime (hours)</b> &rarr; <code>2</code>
@@ -60,7 +62,7 @@ Go to the <a href="https://are.nci.org.au/pun/sys/dashboard/batch_connect/sys/de
     <li>
         <b>Compute Size</b> &rarr; <code>tiny</code> (1 CPU)
         <br>
-        As said above, the ARE VDI session is only needed for setup and startup tasks, which can be easily done with only 1 CPU.
+        As mentioned above, the ARE VDI session is only needed for setup and startup tasks, which can be easily accomplished with 1 CPU.
     </li>
     <li>
         <b>Project</b> &rarr; a project of which you are a member.
@@ -89,13 +91,13 @@ Once the new tab opens, you will see a Desktop with a few folders on the left.
 To open the terminal, click on the black terminal icon at the top of the window. You should now be connected to a <i>Gadi</i> computing node.
 <img src="/assets/run_access_cm/open_are_vdi_terminal.gif" alt="Open ARE VDI terminal" class="example-img" loading="lazy"/>
 
-## Setup {{ model }} persistent session
-To support the use of long-running processes, such as ACCESS models runs, NCI provides a service on <i>Gadi</i> called <a href="https://opus.nci.org.au/display/Help/Persistent+Sessions" target="_blank">persistent sessions</a>.
+## Set up {{ model }} persistent session
+To support the use of long-running processes, such as ACCESS model runs, NCI provides a service on <i>Gadi</i> called <a href="https://opus.nci.org.au/display/Help/Persistent+Sessions" target="_blank">persistent sessions</a>.
 
 To run {{ model }}, you need to start a persistent session and set it as the target session for the model run.
 
 ### Start a new persistent session
-To start a new persistent session on <i>Gadi</i> (in a login node, or in an ARE terminal instance), run the following command:
+To start a new persistent session on <i>Gadi</i>, using either a login node or an ARE terminal instance, run the following command:
 <pre><code>persistent-sessions start &lt;name&gt;</code></pre>
 
 This will start a persistent session with the given <code>name</code> that runs under your <a href="/getting_started/first_steps#change-default-project-on-gadi">default project</a>. 
@@ -193,7 +195,7 @@ module load cylc7/23.09</code></pre>
     <div class="note">
         Make sure to load a version of <i>Cylc</i> >= <code>23.09</code> as earlier versions do not support the persistent sessions workflow.
         <br>
-        Also, before loading the <i>Cylc</i> module, make sure to have started a persistent session and assigned it to the {{ model }} workflow. For more information about these steps, check <a href="{{ '#setup-%s-persistent-session'%model.lower() }}">Setup {{ model }} persistent session</a>.
+        Also, before loading the <i>Cylc</i> module, make sure to have started a persistent session and assigned it to the {{ model }} workflow. For more information about these steps, check <a href="{{ '#set-up-%s-persistent-session'%model.lower() }}">Set up {{ model }} persistent session</a>.
     </div>
     <li>
         <b>MOSRS authentication</b>

--- a/docs/models/run-a-model/run-access-cm.md
+++ b/docs/models/run-a-model/run-access-cm.md
@@ -1,33 +1,6 @@
 {% set model = "ACCESS-CM" %}
-<!-- Tab labels -->
-<div class="tabLabels version-tabs" label="workflow">
-    <button id="are">ARE / <i>Gadi workflow</i></button>
-    <button id="accessdev"><i>accessdev workflow</i></button>
-</div>
-<!-- Tab content -->
-<div class="tabContents" label="workflow">
-    <!-- ARE/Gadi-->
-    <div>
-        <h1>Run {{ model }} from ARE / <i>Gadi</i></h1>
-    </div>
-    <!-- accessdev -->
-    <div>     
-        <h1>Run {{ model }} from <i>accessdev</i></h1>
-    </div>
-</div>
-<!-- End of tab content -->
-
-<div class="note">
-    The workflow to run {{ model }} is currently in transition from <i>accessdev</i> to ARE/<i>Gadi</i>.
-    <br>
-    The above tabs allow you choose the type of workflow you would prefer to follow.
-    <br>
-    <br>
-    If you are new to ACCESS-CM, we <b>strongly recommend</b> that you follow the <b>ARE/<i>Gadi</i></b> workflow, as the <i>accessdev</i> workflow will soon be discontinued.
-</div>
-
+# Run {{ model }}
 ## Prerequisites
-
 ### General prerequisites
 Before running {{ model }}, you need to fulfil general prerequisites outlined in the <a href="/getting_started/first_steps">First Steps</a> section.
 
@@ -51,262 +24,153 @@ If you are unsure whether {{ model }} is the right choice for your experiment, t
         </div>
         For more information on how to join specific NCI projects, refer to <a href="https://opus.nci.org.au/display/Help/How+to+connect+to+a+project" target="_blank">How to connect to a project</a>.
     </li>
-    <!-- Tab content -->
-    <div class="tabContents" label="workflow">
-        <!-- ARE/Gadi-->
-        <div>
-            <li>
-            <b>Connection to an ARE VDI Desktop</b>
-                <br>
-                To run {{ model }}, you need to be able to start an <a href="https://are.nci.org.au/pun/sys/dashboard/batch_connect/sys/desktop_vnc/ncigadi/session_contexts/new" target="_blank">Australian Research Environment (ARE) VDI Desktop</a> session.
-                <br>
-                If you are not familiar with ARE, check out the <a href="/getting_started/are">Getting Started on ARE</a> section.
-            </li>
-        </div>
-        <!-- accessdev -->
-        <div>     
-            <li>
-                <b>Connection to <i>accessdev</i></b>
-                <br>
-                To run {{ model }}, you need to be able to connect to <a href="https://accessdev.nci.org.au/trac/wiki" target="_blank"><i>accessdev</i></a>. This is an NCI server providing configuration and run control for {{ model }}.
-                <br>
-                You also need to ensure there is correct communication between <i>accessdev</i> and <i>Gadi</i>.
-                <br>
-                To complete these steps, refer to the <i>SSH & SSH Agent</i> section in the <a href="https://accessdev.nci.org.au/trac/wiki/GettingConnected">Getting Connected to Accessdev</i></a> guide.
-            </li>
-        </div>
-    </div>
-    <!-- End of tab content -->
+    <li>
+    <b>Connection to an ARE VDI Desktop</b>
+        <br>
+        To run {{ model }}, you need to be able to start an <a href="https://are.nci.org.au/pun/sys/dashboard/batch_connect/sys/desktop_vnc/ncigadi/session_contexts/new" target="_blank">Australian Research Environment (ARE) VDI Desktop</a> session.
+        <br>
+        If you are not familiar with ARE, check out the <a href="/getting_started/are">Getting Started on ARE</a> section.
+    </li>
 </ul>
 
 --------------------------------------------
-## Setup for your chosen workflow
-<div class="tabContents" label="workflow">
-    <!-- ARE/Gadi-->
-    <div>
-        <div class="note">
-            Your chosen workflow is ARE / <i>Gadi</i>. If you would prefer to run {{ model }} on <i>accessdev</i>, then select the <a href="#accessdev"><i>accessdev</i> workflow</a>.
-        </div>
-        <h3>Launch ARE VDI Session</h3>
-        Go to the <a href="https://are.nci.org.au/pun/sys/dashboard/batch_connect/sys/desktop_vnc/ncigadi/session_contexts/new" target="_blank">ARE VDI</a> page and launch a session with the following directives:
-        <ul>
-            <li>
-                <b>Walltime (hours)</b> &rarr; &thickapprox; <code>4</code> per simulated year.
-                <br>
-                With the current state of the ARE/Gadi workflow, <b>the ARE VDI session needs to remain active and running for the entirety of the {{ model }} simulation</b>. If the ARE VDI session expires before the end of the simulation, the simulation itself will be terminated as well.
-                <br>
-                <br>
-                This means that <code>walltime</code> needs to be set according to the simulation length.
-                <br>
-                A good estimate to calculate the <code>walltime</code> needed is <b>4 hours per simulated year</b>.
-                <div class="note">
-                    ARE VDI session cannot be spun up for more than 48 consecutive hours. This means that {{ model }} simulations that need more than 48 hours to complete, at the current state, need to be broken down into multiple chunks running for up to 48 hours.
-                    <br>
-                    <br>
-                    In the near future this will not be necessary anymore, as there will be long running servers in place for runnning {{ model }} simulations.
-                </div>
-            </li>
-            <li>
-                <b>Queue</b> &rarr; <code>normalbw</code>
-            </li>
-            <li>
-                <b>Compute Size</b> &rarr; <code>tiny</code> (1 CPU)
-                <br>
-                {{ model }} runs on a different Gadi node with respect to the one where the ARE VDI session is launched.
-                <br>
-                This means that the ARE VDI session only needs to carry out setup steps as well as starting the run itself. All these tasks can be easily done with only 1 CPU.
-            </li>
-            <li>
-                <b>Project</b> &rarr; a project of which you are a member.
-                <br>
-                The project must have allocated <i>Service Units</i> (SU) to run your simulation. Usually, but not always, this corresponds to your <code>$PROJECT</code>.
-                <br>
-                For more information, refer to how to <a href="/getting_started/first_steps#join-relevant-nci-projects">Join relevant NCI projects</a>.
-            </li>
-            <li>
-                <b>Storage</b> &rarr; <code>gdata/access+gdata/hh5+gdata/hr22+gdata/ki32</code> (minimum)
-                <br>
-                This is a list of all project data storage (joined by <code>+</code> signs) needed for the {{ model }} simulation. In ARE, storage locations need to be explicitly defined to access data from within a VDI instance.
-                <br>
-                Every {{ model }} simulation can be unique and input data can originate from various sources. Hence, if your simulation requires data stored in project folders other than <code>access</code>, <code>hh5</code>, <code>hr22</code> or <code>ki32</code>, you need to add those projects to the storage path.
-                <br>
-                For example, if your {{ model }} simulation requires data stored in <code>/g/data/tm70</code> and <code>/scratch/w40</code>, your full storage path will be: <code>gdata/access+gdata/hh5+gdata/hr22+gdata/ki32<b>+gdata/tm70+scratch/w40</b></code>
-            </li>
-        </ul>
-        Launch the ARE session and, once it starts, click on <i>Launch VDI Desktop</i>.
-        <img src="/assets/run_access_cm/launch_are_vdi.gif" alt="Launch ARE VDI session" class="example-img" loading="lazy"/>
+## Setup ARE VDI Desktop
+### Launch ARE VDI Session
+Go to the <a href="https://are.nci.org.au/pun/sys/dashboard/batch_connect/sys/desktop_vnc/ncigadi/session_contexts/new" target="_blank">ARE VDI</a> page and launch a session with the following directives:
+<ul>
+    <li>
+        <b>Walltime (hours)</b> &rarr; &thickapprox; <code>4</code> per simulated year.
         <br>
-        <h3>Open the terminal</h3>
-        Once the new tab opens, you will see a Desktop with a few folders on the left.
+        With the current state of the ARE/Gadi workflow, <b>the ARE VDI session needs to remain active and running for the entirety of the {{ model }} simulation</b>. If the ARE VDI session expires before the end of the simulation, the simulation itself will be terminated as well.
         <br>
-        To open the terminal, click on the black terminal icon at the top of the window. You should now be connected to a <i>Gadi</i> computing node.
-        <img src="/assets/run_access_cm/open_are_vdi_terminal.gif" alt="Open ARE VDI terminal" class="example-img" loading="lazy"/>
-    </div>
-    <!-- accessdev-->
-    <div>
+        <br>
+        This means that <code>walltime</code> needs to be set according to the simulation length.
+        <br>
+        A good estimate to calculate the <code>walltime</code> needed is <b>4 hours per simulated year</b>.
         <div class="note">
-            Your chosen workflow is <i>accessdev</i>. If you would prefer to run {{ model }} on ARE / <i>Gadi</i>, then select the <a href="#are">ARE / <i>Gadi</i> workflow</a>.
+            ARE VDI session cannot be spun up for more than 48 consecutive hours. This means that {{ model }} simulations that need more than 48 hours to complete, at the current state, need to be broken down into multiple chunks running for up to 48 hours.
+            <br>
+            <br>
+            In the near future this will not be necessary anymore, as there will be long running servers in place for runnning {{ model }} simulations.
         </div>
-        Login to <i>accessdev</i> by runnning:
-        <pre><code>ssh accessdev</code></pre>
-        <div class="note">
-            If you have not yet set up your <i>accessdev</i> connection through `ssh`, please check the <a href="https://accessdev.nci.org.au/trac/wiki/GettingConnected">Getting Connected to Accessdev</i></a> guide.
-        </div>
-    </div>
-</div>
-<!-- End of tab content -->
+    </li>
+    <li>
+        <b>Queue</b> &rarr; <code>normalbw</code>
+    </li>
+    <li>
+        <b>Compute Size</b> &rarr; <code>tiny</code> (1 CPU)
+        <br>
+        {{ model }} runs on a different Gadi node with respect to the one where the ARE VDI session is launched.
+        <br>
+        This means that the ARE VDI session only needs to carry out setup steps as well as starting the run itself. All these tasks can be easily done with only 1 CPU.
+    </li>
+    <li>
+        <b>Project</b> &rarr; a project of which you are a member.
+        <br>
+        The project must have allocated <i>Service Units</i> (SU) to run your simulation. Usually, but not always, this corresponds to your <code>$PROJECT</code>.
+        <br>
+        For more information, refer to how to <a href="/getting_started/first_steps#join-relevant-nci-projects">Join relevant NCI projects</a>.
+    </li>
+    <li>
+        <b>Storage</b> &rarr; <code>gdata/access+gdata/hh5+gdata/hr22+gdata/ki32</code> (minimum)
+        <br>
+        This is a list of all project data storage (joined by <code>+</code> signs) needed for the {{ model }} simulation. In ARE, storage locations need to be explicitly defined to access data from within a VDI instance.
+        <br>
+        Every {{ model }} simulation can be unique and input data can originate from various sources. Hence, if your simulation requires data stored in project folders other than <code>access</code>, <code>hh5</code>, <code>hr22</code> or <code>ki32</code>, you need to add those projects to the storage path.
+        <br>
+        For example, if your {{ model }} simulation requires data stored in <code>/g/data/tm70</code> and <code>/scratch/w40</code>, your full storage path will be: <code>gdata/access+gdata/hh5+gdata/hr22+gdata/ki32<b>+gdata/tm70+scratch/w40</b></code>
+    </li>
+</ul>
+Launch the ARE session and, once it starts, click on <i>Launch VDI Desktop</i>.
+<img src="/assets/run_access_cm/launch_are_vdi.gif" alt="Launch ARE VDI session" class="example-img" loading="lazy"/>
+<br>
+
+### Open the terminal in the VDI Desktop
+Once the new tab opens, you will see a Desktop with a few folders on the left.
+<br>
+To open the terminal, click on the black terminal icon at the top of the window. You should now be connected to a <i>Gadi</i> computing node.
+<img src="/assets/run_access_cm/open_are_vdi_terminal.gif" alt="Open ARE VDI terminal" class="example-img" loading="lazy"/>
 
 ## Get {{ model }} suite
 {{ model }} comprises the model components <a href="../../model_components/atmosphere/#unified-model-um">UM</a>, <a href="../../model_components/ocean/#modular-ocean-model-mom">MOM</a>, <a href="../../model_components/sea-ice/#cice">CICE</a>, <a href="../../model_components/land/#cable">CABLE</a> and <a href="../../model_components/coupler/#oasis3-mct">OASIS</a>. These components, which have different model parameters, input data and computer-related information, need to be packaged together as a <i>suite</i> in order to run.
 <br>
 Each {{ model }} suite has a <code>suite-ID</code> in the format <code>u-&lt;suite-name&gt;</code>, where <code>&lt;suite-name&gt;</code> is a unique identifier.
 <br>
-<div class="tabContents" label="workflow">
-    <!-- ARE/Gadi-->
-    <div>
-        For this example you can use <code>u-cy339</code>, which is a preindustrial experiment suite.
-        <br>
-        Typically, an existing suite is copied and then edited as needed for a particular run.
-    </div>
-    <!-- accessdev -->
-    <div>
-        For this example you can use <code>u-br565</code>, which is the CMIP6-release preindustrial experiment suite.
-        <br>
-        Typically, an existing suite is copied and then edited as needed for a particular run.
-    </div>
-</div>
-<!-- End of tab content -->
+For this example you can use <code>u-cy339</code>, which is a preindustrial experiment suite.
+<br>
+Typically, an existing suite is copied and then edited as needed for a particular run.
+
 
 ### Copy {{ model }} suite with Rosie
 <a href = "http://metomi.github.io/rose/doc/html/tutorial/rose/rosie.html" target="_blank">Rosie</a> is an <a href = "https://subversion.apache.org/" target="_blank">SVN</a> repository wrapper with a set of options specific for {{ model }} suites.
 <br>
-
-<div class="tabContents" label="workflow">
-    <!-- ARE/Gadi -->
-    <div>
-        To copy an existing suite on <i>Gadi</i> you need to follow three main steps:
-        <ol>
-            <li>
-                <b>Get Cylc7 setup</b>
-                <br>
-                To get the Cylc7 setup required to run {{ model }}, execute the following commands:
-                <pre><code>module use /g/data/hr22/modulefiles
+To copy an existing suite on <i>Gadi</i> you need to follow three main steps:
+<ol>
+    <li>
+        <b>Get Cylc7 setup</b>
+        <br>
+        To get the Cylc7 setup required to run {{ model }}, execute the following commands:
+        <pre><code>module use /g/data/hr22/modulefiles
 module load cylc7</code></pre>
-                <terminal-window data="input">
-                    <terminal-line>module use /g/data/hr22/modulefiles</terminal-line>
-                    <terminal-line>module load cylc7</terminal-line>
-                    <terminal-line data="output">Loading cylc7/23.03</terminal-line>
-                    <terminal-line data="output">&emsp;Loading requirement: mosrs-setup/1.0.1</terminal-line>
-                </terminal-window>
-            </li>
-            <li>
-                <b>MOSRS authentication</b>
-                <br>
-                To authenticate using your <i>MOSRS</i> credentials, run:
-                <pre><code>mosrs-auth</code></pre> 
-                <terminal-window>
-                    <terminal-line data="input">mosrs-auth</terminal-line>
-                    <terminal-line lineDelay=500><span style="color: #559cd5;">INFO</span>: You need to enter your MOSRS credentials here so that GPG can cache your password.</terminal-line>
-                    <terminal-line>Please enter the MOSRS password for &lt;MOSRS-username&gt;:</terminal-line>
-                    <terminal-line lineDelay=1500><span style="color: #559cd5;">INFO</span>: Checking your credentials using Subversion. Please wait.</terminal-line>
-                    <terminal-line lineDelay=500><span style="color: #559cd5;">INFO</span>: Successfully accessed Subversion with your credentials.</terminal-line>
-                    <terminal-line lineDelay=100><span style="color: #559cd5;">INFO</span>: Checking your credentials using rosie. Please wait.</terminal-line>
-                    <terminal-line lineDelay=500><span style="color: #559cd5;">INFO</span>: Successfully accessed rosie with your credentials.</terminal-line>
-                </terminal-window>
-            </li>
-            <li>
-                <b>Copy a suite</b>
-                <br>
-                <ul>
-                    <li>
-                        <i>Local-only copy</i>
-                        <br>
-                        To create a <i>local copy</i> of the <code>&lt;suite-ID&gt;</code> from the UKMO repository, run:
-                        <pre><code>rosie checkout &lt;suite-ID&gt;</code></pre>
-                        <terminal-window>
-                            <terminal-line data="input">rosie checkout &lt;suite-ID&gt;</terminal-line>
-                            <terminal-line>[INFO] create: /home/565/&lt;$USER&gt;/roses</terminal-line>
-                            <terminal-line>[INFO] &lt;suite-ID&gt;: local copy created at /home/565/&lt;$USER&gt;/roses/&lt;suite-ID&gt;</terminal-line>
-                        </terminal-window>
-                        This option is mostly used for testing and examining existing suites.
-                    </li>
-                    <li>
-                        <i>Remote and local copy</i>
-                        <br> 
-                        Alternatively, to create a new copy of an existing <code>&lt;suite-ID&gt;</code> both <i>locally and remotely</i> in the UKMO repository, run: 
-                        <pre><code>rosie copy &lt;suite-ID&gt;</code></pre>
-                        <terminal-window>
-                            <terminal-line data="input">rosie copy &lt;suite-ID&gt;</terminal-line>
-                            <terminal-line>Copy "&lt;suite-ID&gt;/trunk@&lt;trunk-ID&gt;" to "u-?????"? [y or n (default)]</terminal-line> <terminal-line data="input">y</terminal-line>
-                            <terminal-line>[INFO] &lt;new-suite-ID&gt;: created at https://code.metoffice.gov.uk/svn/roses-u/&lt;suite-n/a/m/e/&gt;</terminal-line>
-                            <terminal-line>[INFO] &lt;new-suite-ID&gt;: copied items from &lt;suite-ID&gt;/trunk@&lt;trunk-ID&gt;</terminal-line>
-                            <terminal-line>[INFO] &lt;suite-ID&gt;: local copy created at /home/565/&lt;$USER&gt;/roses/&lt;new-suite-ID&gt;</terminal-line>
-                        </terminal-window>
-                        When a new suite is created in this way, a <i>unique</i> <code>&lt;suite-ID&gt;</code> is generated within the repository and populated with descriptive information about the suite and its initial configuration.
-                    </li>
-                </ul>
-            </li>
-        </ol>
-        For additional <code>rosie</code> options, run:
-        <pre><code>rosie help</code></pre>
+        <terminal-window data="input">
+            <terminal-line>module use /g/data/hr22/modulefiles</terminal-line>
+            <terminal-line>module load cylc7</terminal-line>
+            <terminal-line data="output">Loading cylc7/23.03</terminal-line>
+            <terminal-line data="output">&emsp;Loading requirement: mosrs-setup/1.0.1</terminal-line>
+        </terminal-window>
+    </li>
+    <li>
+        <b>MOSRS authentication</b>
         <br>
-        Suites are created in the user's home directory on <i>Gadi</i> under <code>~/roses/&lt;suite-ID&gt;</code>.
-    </div>
-    <!-- accessdev -->
-    <div>
-        To copy an existing suite on <i>accessdev</i> you need to follow two main steps:
-        <ol>
-            <li>
-                <b>MOSRS authentication</b>
-                <br>
-                To authenticate using your <i>MOSRS</i> credentials, run:
-                <pre><code>mosrs-auth</code></pre> 
-                <terminal-window>
-                    <terminal-line data="input">mosrs-auth</terminal-line>
-                    <terminal-line>Please enter the MOSRS password for &lt;MOSRS-username&gt;:</terminal-line>
-                    <terminal-line lineDelay=1000>Successfully authenticated with MOSRS as &lt;MOSRS-username&gt;</terminal-line>
-                </terminal-window>
-            </li>
-            <li>
-                <b>Copy a suite</b>
-                <br>
-                <ul>
-                    <li>
-                        <i>Local-only copy</i>
-                        <br>
-                        To create a <i>local copy</i> of the <code>&lt;suite-ID&gt;</code> from the UKMO repository, run:
-                        <pre><code>rosie checkout &lt;suite-ID&gt;</code></pre>
-                        <terminal-window>
-                            <terminal-line data="input">rosie checkout &lt;suite-ID&gt;</terminal-line>
-                            <terminal-line>[INFO] create: /home/565/&lt;$USER&gt;/roses</terminal-line>
-                            <terminal-line>[INFO] &lt;suite-ID&gt;: local copy created at /home/565/&lt;$USER&gt;/roses/&lt;suite-ID&gt;</terminal-line>
-                        </terminal-window>
-                        This option is mostly used for testing and examining existing suites.
-                    </li>
-                    <li>
-                        <i>Remote and local copy</i>
-                        <br> 
-                        Alternatively, to create a new copy of an existing <code>&lt;suite-ID&gt;</code> both <i>locally and remotely</i> in the UKMO repository, run: 
-                        <pre><code>rosie copy &lt;suite-ID&gt;</code></pre>
-                        <terminal-window>
-                            <terminal-line data="input">rosie copy &lt;suite-ID&gt;</terminal-line>
-                            <terminal-line>Copy "&lt;suite-ID&gt;/trunk@&lt;trunk-ID&gt;" to "u-?????"? [y or n (default)]</terminal-line> <terminal-line data="input">y</terminal-line>
-                            <terminal-line>[INFO] &lt;new-suite-ID&gt;: created at https://code.metoffice.gov.uk/svn/roses-u/&lt;suite-n/a/m/e/&gt;</terminal-line>
-                            <terminal-line>[INFO] &lt;new-suite-ID&gt;: copied items from &lt;suite-ID&gt;/trunk@&lt;trunk-ID&gt;</terminal-line>
-                            <terminal-line>[INFO] &lt;suite-ID&gt;: local copy created at /home/565/&lt;$USER&gt;/roses/&lt;new-suite-ID&gt;</terminal-line>
-                        </terminal-window>
-                        When a new suite is created in this way, a <i>unique</i> <code>&lt;suite-ID&gt;</code> is generated within the repository and populated with descriptive information about the suite and its initial configuration.
-                    </li>
-                </ul>
-            </li>
-        </ol>
-        For additional <code>rosie</code> options, run:
-        <pre><code>rosie help</code></pre>
+        To authenticate using your <i>MOSRS</i> credentials, run:
+        <pre><code>mosrs-auth</code></pre> 
+        <terminal-window>
+            <terminal-line data="input">mosrs-auth</terminal-line>
+            <terminal-line lineDelay=500><span style="color: #559cd5;">INFO</span>: You need to enter your MOSRS credentials here so that GPG can cache your password.</terminal-line>
+            <terminal-line>Please enter the MOSRS password for &lt;MOSRS-username&gt;:</terminal-line>
+            <terminal-line lineDelay=1500><span style="color: #559cd5;">INFO</span>: Checking your credentials using Subversion. Please wait.</terminal-line>
+            <terminal-line lineDelay=500><span style="color: #559cd5;">INFO</span>: Successfully accessed Subversion with your credentials.</terminal-line>
+            <terminal-line lineDelay=100><span style="color: #559cd5;">INFO</span>: Checking your credentials using rosie. Please wait.</terminal-line>
+            <terminal-line lineDelay=500><span style="color: #559cd5;">INFO</span>: Successfully accessed rosie with your credentials.</terminal-line>
+        </terminal-window>
+    </li>
+    <li>
+        <b>Copy a suite</b>
         <br>
-        Suites are created in the user's home directory on <i>accessdev</i> under <code>~/roses/&lt;suite-ID&gt;</code>.
-    </div>
-</div>
-<!-- End of Tab Content -->
+        <ul>
+            <li>
+                <i>Local-only copy</i>
+                <br>
+                To create a <i>local copy</i> of the <code>&lt;suite-ID&gt;</code> from the UKMO repository, run:
+                <pre><code>rosie checkout &lt;suite-ID&gt;</code></pre>
+                <terminal-window>
+                    <terminal-line data="input">rosie checkout &lt;suite-ID&gt;</terminal-line>
+                    <terminal-line>[INFO] create: /home/565/&lt;$USER&gt;/roses</terminal-line>
+                    <terminal-line>[INFO] &lt;suite-ID&gt;: local copy created at /home/565/&lt;$USER&gt;/roses/&lt;suite-ID&gt;</terminal-line>
+                </terminal-window>
+                This option is mostly used for testing and examining existing suites.
+            </li>
+            <li>
+                <i>Remote and local copy</i>
+                <br> 
+                Alternatively, to create a new copy of an existing <code>&lt;suite-ID&gt;</code> both <i>locally and remotely</i> in the UKMO repository, run: 
+                <pre><code>rosie copy &lt;suite-ID&gt;</code></pre>
+                <terminal-window>
+                    <terminal-line data="input">rosie copy &lt;suite-ID&gt;</terminal-line>
+                    <terminal-line>Copy "&lt;suite-ID&gt;/trunk@&lt;trunk-ID&gt;" to "u-?????"? [y or n (default)]</terminal-line> <terminal-line data="input">y</terminal-line>
+                    <terminal-line>[INFO] &lt;new-suite-ID&gt;: created at https://code.metoffice.gov.uk/svn/roses-u/&lt;suite-n/a/m/e/&gt;</terminal-line>
+                    <terminal-line>[INFO] &lt;new-suite-ID&gt;: copied items from &lt;suite-ID&gt;/trunk@&lt;trunk-ID&gt;</terminal-line>
+                    <terminal-line>[INFO] &lt;suite-ID&gt;: local copy created at /home/565/&lt;$USER&gt;/roses/&lt;new-suite-ID&gt;</terminal-line>
+                </terminal-window>
+                When a new suite is created in this way, a <i>unique</i> <code>&lt;suite-ID&gt;</code> is generated within the repository and populated with descriptive information about the suite and its initial configuration.
+            </li>
+        </ul>
+    </li>
+</ol>
+For additional <code>rosie</code> options, run:
+<pre><code>rosie help</code></pre>
+<br>
+Suites are created in the user's home directory on <i>Gadi</i> under <code>~/roses/&lt;suite-ID&gt;</code>.
 Each suite directory usually contains two subdirectories and three files:
 <ul>
     <li><code>app</code> &rarr; directory containing the configuration files for various tasks within the suite.</li>
@@ -332,46 +196,19 @@ To edit a suite configuration, run the following command from within the suite d
 <div class="note">
     The <code>&</code> is optional. It allows the terminal prompt to remain active while running the <i>Rose</i> GUI as a separate process in the background.
 </div>
-<div class="tabContents" label="workflow">
-    <!-- ARE/Gadi -->
-    <div>
-        <terminal-window>
-            <terminal-line data="input">cd ~/roses/&lt;suite-ID&gt;</terminal-line>
-            <terminal-line data="input" directory="~/roses/&lt;suite-ID&gt;">rose edit &</terminal-line>
-            <terminal-line class="ls-output-format">[&lt;N&gt;] &lt;PID&gt;</terminal-line>
-            <terminal-line data="input" directory="~/roses/&lt;suite-ID&gt;"></terminal-line>
-            <img src="/assets/run_access_cm/Rose_GUI_are.png" alt="Rose GUI" imageTime="inf" loading="lazy">
-        </terminal-window>
-    </div>
-    <!-- accessdev -->
-    <div>
-        <terminal-window>
-            <terminal-line data="input">cd ~/roses/&lt;suite-ID&gt;</terminal-line>
-            <terminal-line data="input" directory="~/roses/&lt;suite-ID&gt;">rose edit &</terminal-line>
-            <terminal-line class="ls-output-format">[&lt;N&gt;] &lt;PID&gt;</terminal-line>
-            <terminal-line data="input" directory="~/roses/&lt;suite-ID&gt;"></terminal-line>
-            <img src="/assets/run_access_cm/Rose GUI.png" alt="Rose GUI" imageTime="inf" loading="lazy">
-        </terminal-window>
-    </div>
-</div>
-<!-- End of tab content -->
-
+<terminal-window>
+    <terminal-line data="input">cd ~/roses/&lt;suite-ID&gt;</terminal-line>
+    <terminal-line data="input" directory="~/roses/&lt;suite-ID&gt;">rose edit &</terminal-line>
+    <terminal-line class="ls-output-format">[&lt;N&gt;] &lt;PID&gt;</terminal-line>
+    <terminal-line data="input" directory="~/roses/&lt;suite-ID&gt;"></terminal-line>
+    <img src="/assets/run_access_cm/Rose_GUI_are.png" alt="Rose GUI" imageTime="inf" loading="lazy">
+</terminal-window>
+    
 ### Change NCI project
 To ensure that your suite is run under the correct NCI project for which you are a member, edit the <i>Compute project</i> field in <i>suite conf &rarr; Machine and Runtime Options</i>, and click the <i>Save</i> button <img src="/assets/run_access_cm/save_button.png" alt="Save button" style="height:1em"/>. 
 <br> <br>
 For example, to run an {{ model }} suite under the <code>tm70</code> project (ACCESS-NRI), enter <code>tm70</code> in the <i>Compute project</i> field:
-
-<div class="tabContents" label="workflow">
-    <!-- ARE / Gadi -->
-    <div>
-        <img src="/assets/run_access_cm/rose_change_project_are.gif" alt="Rose change project" class="example-img" loading="lazy"/>
-    </div>
-    <!-- accessdev -->
-    <div>
-        <img src="/assets/run_access_cm/rose_change_project.gif" alt="Rose change project" class="example-img" loading="lazy"/>
-    </div>
-</div>
-<!-- End of tab content -->
+<img src="/assets/run_access_cm/rose_change_project_are.gif" alt="Rose change project" class="example-img" loading="lazy"/>
 <div class="note">
     To run {{ model }}, you need to be a member of a project with allocated <i>Service Units</i> (SU). For more information, check how to <a href="/getting_started/first_steps#join-relevant-nci-projects">Join relevant NCI projects</a>.
 </div>
@@ -384,19 +221,7 @@ To modify these parameters, navigate to <i>suite conf &rarr; Run Initialisation 
 <br> 
 <br>
 For example, to run a suite for a total of 50 years with a 1-year job resubmission, change <i>Total Run length</i> to <code>P50Y</code> and <i>Cycling frequency</i> to <code>P1Y</code> (the maximum <i>Cycling frequency</i> is currently two years):
-
-
-<div class="tabContents" label="workflow">
-    <!-- ARE / Gadi -->
-    <div>
-        <img src="/assets/run_access_cm/rose_change_run_length_are.gif" alt="Rose change run length" class="example-img" loading="lazy"/>
-    </div>
-    <!-- accessdev -->
-    <div>
-        <img src="/assets/run_access_cm/rose_change_run_length.gif" alt="Rose change run length" class="example-img" loading="lazy"/>
-    </div>
-</div>
-<!-- End of tab content -->
+<img src="/assets/run_access_cm/rose_change_run_length_are.gif" alt="Rose change run length" class="example-img" loading="lazy"/>
 
 ### Change wallclock time
 The <i>Wallclock time</i> is the time requested by the <a href="https://opus.nci.org.au/display/Help/4.+PBS+Jobs" target="_blank">PBS job</a> to run a single cycle. If this time is insufficient for the suite to complete a cycle, your job will be terminated before completing the run. Hence, if you change the <i>Cycling frequency</i>, you may also need to change the <i>Wallclock time</i> accordingly. While the time required for a suite to complete a cycle depends on several factors, a good estimation is 4 hours per simulated year.
@@ -404,7 +229,6 @@ The <i>Wallclock time</i> is the time requested by the <a href="https://opus.nci
 <br>
 To modify the <i>Wallclock time</i>, edit the respective field in <i>suite conf &rarr; Run Initialisation and Cycling</i> (using <a href="https://en.wikipedia.org/wiki/ISO_8601#Durations" target="_blank">ISO 8601 Duration</a> format) and click the <i>Save</i> button <img src="/assets/run_access_cm/save_button.png" alt="Save button" style="height:1em"/>. 
 
-<!-- TO DO For more details on how to edit other suite parameters using Rose GUI, such as component configurations, output variables (STASH), or science settings, check <a href="../rose_gui_user_guide" target="_blank">Rose GUI user guide</a>. -->
 ----------------------------------------------------------------------------------------
 
 ## Run {{ model }} suite
@@ -422,117 +246,59 @@ To run an {{ model }} suite run the following command from within the suite dire
 <pre><code>rose suite-run</code></pre>
 
 After the initial tasks are executed, the <i>Cylc</i> GUI will open. You can now view and control the different tasks in the suite as they are run:
-
-<div class="tabContents" label="workflow">
-    <!-- ARE / Gadi -->
-    <div>
-        <terminal-window lineDelay="50">
-            <terminal-line data="input" lineDelay="300">cd ~/roses/&lt;suite-ID&gt;</terminal-line>
-            <terminal-line data="input" directory="~/roses/&lt;suite-ID&gt;" lineDelay="300">rose suite-run</terminal-line>
-            <terminal-line>[INFO] export CYLC_VERSION=7.9.7</terminal-line>
-            <terminal-line>export ROSE_ORIG_HOST=&lt;gadi-cpu&gt;.gadi.nci.org.au</terminal-line>
-            <terminal-line>[INFO] export ROSE_SITE=nci</terminal-line>
-            <terminal-line>[INFO] export ROSE_VERSION=2019.01.7</terminal-line>
-            <terminal-line>[INFO] create: /home/565/&lt;$USER&gt;/cylc-run/&lt;suite-ID&gt;</terminal-line>
-            <terminal-line>[INFO] create: log.&lt;timestamp&gt;</terminal-line>
-            <terminal-line>[INFO] symlink: log.&lt;timestamp&gt; <= log</terminal-line>
-            <terminal-line>[INFO] create: log/suite</terminal-line>
-            <terminal-line>[INFO] create: log/rose-conf</terminal-line>
-            <terminal-line>[INFO] symlink: rose-conf/&lt;timestamp&gt;-run.conf <= log/rose-suite-run.conf</terminal-line>
-            <terminal-line>[INFO] symlink: rose-conf/&lt;timestamp&gt;-run.version <= log/rose-suite-run.version</terminal-line>
-            <terminal-line>[INFO] create: meta</terminal-line>
-            <terminal-line>[INFO] install: meta</terminal-line>
-            <terminal-line>&emsp;&emsp;&emsp;&emsp;source: /home/565/&lt;$USER&gt;/roses/&lt;suite-ID&gt;/meta</terminal-line>
-            <terminal-line>[INFO] install: rose-suite.info</terminal-line>
-            <terminal-line>&emsp;&emsp;&emsp;&emsp;source: /home/565/&lt;$USER&gt;/roses/&lt;suite-ID&gt;/rose-suite.info</terminal-line>
-            <terminal-line>[INFO] create: app</terminal-line>
-            <terminal-line>[INFO] install: app</terminal-line>
-            <terminal-line>&emsp;&emsp;&emsp;&emsp;source: /home/565/&lt;$USER&gt;/roses/&lt;suite-ID&gt;/app</terminal-line>
-            <terminal-line>[INFO] install: suite.rc</terminal-line>
-            <terminal-line>[INFO] REGISTERED &lt;suite-ID&gt; -> /home/565/&lt;$USER&gt;/cylc-run/&lt;suite-ID&gt;</terminal-line>
-            <terminal-line>[INFO] create: share</terminal-line>
-            <terminal-line>[INFO] create: share/cycle</terminal-line>
-            <terminal-line>[INFO] create: work</terminal-line>
-            <terminal-line>[INFO] chdir: log/</terminal-line>
-            <terminal-line>[INFO] &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;&thinsp;._.</terminal-line>
-            <terminal-line>[INFO] &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;&thinsp;| |&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;The Cylc Suite Engine [7.9.7]</terminal-line>
-            <terminal-line>[INFO] ._____._. ._| |_____.&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;Copyright (C) 2008-2019 NIWA</terminal-line>
-            <terminal-line>[INFO] | .___| | | | | .___|&emsp;& British Crown (Met Office) & Contributors.</terminal-line>
-            <terminal-line>[INFO] | !___| !_! | | !___. _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _</terminal-line>
-            <terminal-line>[INFO] !_____!___. |_!_____! This program comes with ABSOLUTELY NO WARRANTY;</terminal-line>
-            <terminal-line>[INFO] &emsp;&emsp;&emsp;&thinsp;.___! | &emsp;&emsp;&emsp;&emsp;&emsp;see `cylc warranty`. &thinsp;It is free software, you</terminal-line>
-            <terminal-line>[INFO] &emsp;&emsp;&emsp;&thinsp;!_____! &emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;are welcome to redistribute it under certain</terminal-line>
-            <terminal-line>[INFO]</terminal-line>
-            <terminal-line>[INFO] *** listening on https://&lt;gadi-cpu&gt;.gadi.nci.org.au:&lt;port&gt;/ ***</terminal-line>
-            <terminal-line>[INFO]</terminal-line>
-            <terminal-line>[INFO] To view suite server program contact information:</terminal-line>
-            <terminal-line>[INFO]  $ cylc get-suite-contact &lt;suite-ID&gt;</terminal-line>
-            <terminal-line>[INFO]</terminal-line>
-            <terminal-line>[INFO] Other ways to see if the suite is still running:</terminal-line>
-            <terminal-line>[INFO]  $ cylc scan -n '&lt;suite-ID&gt;' &lt;gadi-cpu&gt;.gadi.nci.org.au</terminal-line>
-            <terminal-line>[INFO]  $ cylc ping -v --host=&lt;gadi-cpu&gt;.nci.org.au &lt;suite-ID&gt;</terminal-line>
-            <terminal-line>[INFO]  $ ps -opid,args &lt;PID&gt;  # on &lt;gadi-cpu&gt;.nci.org.au</terminal-line>
-            <img src="/assets/run_access_cm/Cylc_GUI_are.png" alt="Cylc GUI" imageTime="inf" loading="lazy">
-        </terminal-window>
-    </div>
-    <!-- accessdev -->
-    <div>
-        <terminal-window lineDelay="50">
-            <terminal-line data="input" lineDelay="300">cd ~/roses/&lt;suite-ID&gt;</terminal-line>
-            <terminal-line data="input" directory="~/roses/&lt;suite-ID&gt;" lineDelay="300">rose suite-run</terminal-line>
-            <terminal-line>[INFO] export CYLC_VERSION=7.8.3</terminal-line>
-            <terminal-line>[INFO] export ROSE_ORIG_HOST=accessdev.nci.org.au</terminal-line>
-            <terminal-line>[INFO] export ROSE_SITE=</terminal-line>
-            <terminal-line>[INFO] export ROSE_VERSION=2019.01.2</terminal-line>
-            <terminal-line>[INFO] create: /home/565/&lt;$USER&gt;/cylc-run/&lt;suite-ID&gt;</terminal-line>
-            <terminal-line>[INFO] create: log.&lt;timestamp&gt;</terminal-line>
-            <terminal-line>[INFO] symlink: log.&lt;timestamp&gt; <= log</terminal-line>
-            <terminal-line>[INFO] create: log/suite</terminal-line>
-            <terminal-line>[INFO] create: log/rose-conf</terminal-line>
-            <terminal-line>[INFO] symlink: rose-conf/&lt;timestamp&gt;-run.conf <= log/rose-suite-run.conf</terminal-line>
-            <terminal-line>[INFO] symlink: rose-conf/&lt;timestamp&gt;-run.version <= log/rose-suite-run.version</terminal-line>
-            <terminal-line>[INFO] install: rose-suite.info</terminal-line>
-            <terminal-line>&emsp;&emsp;&emsp;&emsp;source: /home/565/&lt;$USER&gt;/roses/&lt;suite-ID&gt;/rose-suite.info</terminal-line>
-            <terminal-line>[INFO] create: app</terminal-line>
-            <terminal-line>[INFO] install: app</terminal-line>
-            <terminal-line>&emsp;&emsp;&emsp;&emsp;source: /home/565/&lt;$USER&gt;/roses/&lt;suite-ID&gt;/app</terminal-line>
-            <terminal-line>[INFO] create: meta</terminal-line>
-            <terminal-line>[INFO] install: meta</terminal-line>
-            <terminal-line>&emsp;&emsp;&emsp;&emsp;source: /home/565/&lt;$USER&gt;/roses/&lt;suite-ID&gt;/meta</terminal-line>
-            <terminal-line>[INFO] install: suite.rc</terminal-line>
-            <terminal-line>[INFO] REGISTERED &lt;suite-ID&gt; -> /home/565/&lt;$USER&gt;/cylc-run/&lt;suite-ID&gt;</terminal-line>
-            <terminal-line>[INFO] create: share</terminal-line>
-            <terminal-line>[INFO] install: share</terminal-line>
-            <terminal-line>[INFO] create: work</terminal-line>
-            <terminal-line>[INFO] chdir: log/</terminal-line>
-            <terminal-line>[INFO] &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;&thinsp;._.</terminal-line>
-            <terminal-line>[INFO] &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;&thinsp;| |&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;The Cylc Suite Engine [7.8.3]</terminal-line>
-            <terminal-line>[INFO] ._____._. ._| |_____.&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;Copyright (C) 2008-2019 NIWA</terminal-line>
-            <terminal-line>[INFO] | .___| | | | | .___|&emsp;& British Crown (Met Office) & Contributors.</terminal-line>
-            <terminal-line>[INFO] | !___| !_! | | !___. _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _</terminal-line>
-            <terminal-line>[INFO] !_____!___. |_!_____! This program comes with ABSOLUTELY NO WARRANTY;</terminal-line>
-            <terminal-line>[INFO] &emsp;&emsp;&emsp;&thinsp;.___! | &emsp;&emsp;&emsp;&emsp;&emsp;see `cylc warranty`. &thinsp;It is free software, you</terminal-line>
-            <terminal-line>[INFO] &emsp;&emsp;&emsp;&thinsp;!_____! &emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;are welcome to redistribute it under certain</terminal-line>
-            <terminal-line>[INFO]</terminal-line>
-            <terminal-line>[INFO] *** listening on https://accessdev.nci.org.au:&lt;port&gt;/ ***</terminal-line>
-            <terminal-line>[INFO]</terminal-line>
-            <terminal-line>[INFO] To view suite server program contact information:</terminal-line>
-            <terminal-line>[INFO]  $ cylc get-suite-contact &lt;suite-ID&gt;</terminal-line>
-            <terminal-line>[INFO]</terminal-line>
-            <terminal-line>[INFO] Other ways to see if the suite is still running:</terminal-line>
-            <terminal-line>[INFO]  $ cylc scan -n '&lt;suite-ID&gt;' accessdev.nci.org.au</terminal-line>
-            <terminal-line>[INFO]  $ cylc ping -v --host=accessdev.nci.org.au &lt;suite-ID&gt;</terminal-line>
-            <terminal-line>[INFO]  $ ps -opid,args &lt;PID&gt;  # on accessdev.nci.org.au</terminal-line>
-            <img src="/assets/run_access_cm/Cylc_GUI.png" alt="Cylc GUI" imageTime="inf" loading="lazy">
-        </terminal-window>
-    </div>
-</div>
-<!-- End of tab content -->
+<terminal-window lineDelay="50">
+    <terminal-line data="input" lineDelay="300">cd ~/roses/&lt;suite-ID&gt;</terminal-line>
+    <terminal-line data="input" directory="~/roses/&lt;suite-ID&gt;" lineDelay="300">rose suite-run</terminal-line>
+    <terminal-line>[INFO] export CYLC_VERSION=7.9.7</terminal-line>
+    <terminal-line>export ROSE_ORIG_HOST=&lt;gadi-cpu&gt;.gadi.nci.org.au</terminal-line>
+    <terminal-line>[INFO] export ROSE_SITE=nci</terminal-line>
+    <terminal-line>[INFO] export ROSE_VERSION=2019.01.7</terminal-line>
+    <terminal-line>[INFO] create: /home/565/&lt;$USER&gt;/cylc-run/&lt;suite-ID&gt;</terminal-line>
+    <terminal-line>[INFO] create: log.&lt;timestamp&gt;</terminal-line>
+    <terminal-line>[INFO] symlink: log.&lt;timestamp&gt; <= log</terminal-line>
+    <terminal-line>[INFO] create: log/suite</terminal-line>
+    <terminal-line>[INFO] create: log/rose-conf</terminal-line>
+    <terminal-line>[INFO] symlink: rose-conf/&lt;timestamp&gt;-run.conf <= log/rose-suite-run.conf</terminal-line>
+    <terminal-line>[INFO] symlink: rose-conf/&lt;timestamp&gt;-run.version <= log/rose-suite-run.version</terminal-line>
+    <terminal-line>[INFO] create: meta</terminal-line>
+    <terminal-line>[INFO] install: meta</terminal-line>
+    <terminal-line>&emsp;&emsp;&emsp;&emsp;source: /home/565/&lt;$USER&gt;/roses/&lt;suite-ID&gt;/meta</terminal-line>
+    <terminal-line>[INFO] install: rose-suite.info</terminal-line>
+    <terminal-line>&emsp;&emsp;&emsp;&emsp;source: /home/565/&lt;$USER&gt;/roses/&lt;suite-ID&gt;/rose-suite.info</terminal-line>
+    <terminal-line>[INFO] create: app</terminal-line>
+    <terminal-line>[INFO] install: app</terminal-line>
+    <terminal-line>&emsp;&emsp;&emsp;&emsp;source: /home/565/&lt;$USER&gt;/roses/&lt;suite-ID&gt;/app</terminal-line>
+    <terminal-line>[INFO] install: suite.rc</terminal-line>
+    <terminal-line>[INFO] REGISTERED &lt;suite-ID&gt; -> /home/565/&lt;$USER&gt;/cylc-run/&lt;suite-ID&gt;</terminal-line>
+    <terminal-line>[INFO] create: share</terminal-line>
+    <terminal-line>[INFO] create: share/cycle</terminal-line>
+    <terminal-line>[INFO] create: work</terminal-line>
+    <terminal-line>[INFO] chdir: log/</terminal-line>
+    <terminal-line>[INFO] &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;&thinsp;._.</terminal-line>
+    <terminal-line>[INFO] &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;&thinsp;| |&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;The Cylc Suite Engine [7.9.7]</terminal-line>
+    <terminal-line>[INFO] ._____._. ._| |_____.&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;Copyright (C) 2008-2019 NIWA</terminal-line>
+    <terminal-line>[INFO] | .___| | | | | .___|&emsp;& British Crown (Met Office) & Contributors.</terminal-line>
+    <terminal-line>[INFO] | !___| !_! | | !___. _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _</terminal-line>
+    <terminal-line>[INFO] !_____!___. |_!_____! This program comes with ABSOLUTELY NO WARRANTY;</terminal-line>
+    <terminal-line>[INFO] &emsp;&emsp;&emsp;&thinsp;.___! | &emsp;&emsp;&emsp;&emsp;&emsp;see `cylc warranty`. &thinsp;It is free software, you</terminal-line>
+    <terminal-line>[INFO] &emsp;&emsp;&emsp;&thinsp;!_____! &emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;are welcome to redistribute it under certain</terminal-line>
+    <terminal-line>[INFO]</terminal-line>
+    <terminal-line>[INFO] *** listening on https://&lt;gadi-cpu&gt;.gadi.nci.org.au:&lt;port&gt;/ ***</terminal-line>
+    <terminal-line>[INFO]</terminal-line>
+    <terminal-line>[INFO] To view suite server program contact information:</terminal-line>
+    <terminal-line>[INFO]  $ cylc get-suite-contact &lt;suite-ID&gt;</terminal-line>
+    <terminal-line>[INFO]</terminal-line>
+    <terminal-line>[INFO] Other ways to see if the suite is still running:</terminal-line>
+    <terminal-line>[INFO]  $ cylc scan -n '&lt;suite-ID&gt;' &lt;gadi-cpu&gt;.gadi.nci.org.au</terminal-line>
+    <terminal-line>[INFO]  $ cylc ping -v --host=&lt;gadi-cpu&gt;.nci.org.au &lt;suite-ID&gt;</terminal-line>
+    <terminal-line>[INFO]  $ ps -opid,args &lt;PID&gt;  # on &lt;gadi-cpu&gt;.nci.org.au</terminal-line>
+    <img src="/assets/run_access_cm/Cylc_GUI_are.png" alt="Cylc GUI" imageTime="inf" loading="lazy">
+</terminal-window>
 <div class="note">
     After running the command <code>rose suite-run</code>, if you get an error similar to the following:
     <pre><code><span style="color: orangered">[FAIL]</span> Suite "&lt;suite-ID&gt;" appears to be running:
 <span style="color: orangered">[FAIL]</span> Contact info from: "/home/565/&lt;$USER&gt;/cylc-run/&lt;suite-ID&gt;/.service/contact"
-<span style="color: orangered">[FAIL]</span>    CYLC_SUITE_HOST=accessdev.nci.org.au
+<span style="color: orangered">[FAIL]</span>    CYLC_SUITE_HOST=gadi.nci.org.au
 <span style="color: orangered">[FAIL]</span>    CYLC_SUITE_OWNER=&lt;$USER&gt;
 <span style="color: orangered">[FAIL]</span>    CYLC_SUITE_PORT=&lt;port&gt;
 <span style="color: orangered">[FAIL]</span>    CYLC_SUITE_PROCESS=&lt;PID&gt; python2 /usr/local/cylc/cylc-7.8.3/bin/cylc-run &lt;suite-ID&gt;
@@ -563,17 +329,7 @@ To investigate the cause of a failure, we need to look at the logs <code>job.err
         <br>
         To access a specific task, click on the arrow next to the task to extend the drop-down menu with all the subtasks.
         <br>
-        <div class="tabContents" label="workflow">
-            <!-- ARE / Gadi -->
-            <div>
-                <img src="/assets/run_access_cm/investigate_error_gui_are.gif" alt="Investigate Error GUI" class="example-img" loading="lazy"/>
-            </div>
-            <!-- accessdev -->
-            <div>
-                <img src="/assets/run_access_cm/investigate_error_gui.gif" alt="Investigate Error GUI" class="example-img" loading="lazy"/>
-            </div>
-        </div>
-        <!-- End of tab content -->
+        <img src="/assets/run_access_cm/investigate_error_gui_are.gif" alt="Investigate Error GUI" class="example-img" loading="lazy"/>
     </li>
     <li>
         <b>Through the suite directory</b>
@@ -626,29 +382,13 @@ To scan for active suites, run:
 <pre><code>cylc scan</code></pre>
 To reopen the <i>Cylc</i> GUI, run the following command from within the suite directory:
 <pre><code>rose suite-gcontrol</code></pre>
-<div class="tabContents" label="workflow">
-    <!-- ARE / Gadi -->
-    <div>
-        <terminal-window>
-            <terminal-line data="input">cylc scan</terminal-line>
-            <terminal-line>&lt;suite-ID&gt; &lt;$USER&gt;@&lt;gadi-cpu&gt;.nci.org.au:&lt;port&gt;</terminal-line>
-            <terminal-line data="input">cd ~/roses/&lt;suite-ID&gt;</terminal-line>
-            <terminal-line data="input" directory="~/roses/&lt;suite-ID&gt;">rose suite-gcontrol</terminal-line>
-            <img src="/assets/run_access_cm/Cylc_GUI_are.png" alt="Cylc GUI" imageTime="inf" loading="lazy">
-        </terminal-window>
-    </div>
-    <!-- accessdev -->
-    <div>
-        <terminal-window>
-            <terminal-line data="input">cylc scan</terminal-line>
-            <terminal-line>&lt;suite-ID&gt; &lt;$USER&gt;@accessdev.nci.org.au:&lt;port&gt;</terminal-line>
-            <terminal-line data="input">cd ~/roses/&lt;suite-ID&gt;</terminal-line>
-            <terminal-line data="input" directory="~/roses/&lt;suite-ID&gt;">rose suite-gcontrol</terminal-line>
-            <img src="/assets/run_access_cm/Cylc_GUI.png" alt="Cylc GUI" imageTime="inf" loading="lazy">
-        </terminal-window>
-    </div>
-</div>
-<!-- End of tab content -->
+<terminal-window>
+    <terminal-line data="input">cylc scan</terminal-line>
+    <terminal-line>&lt;suite-ID&gt; &lt;$USER&gt;@&lt;gadi-cpu&gt;.nci.org.au:&lt;port&gt;</terminal-line>
+    <terminal-line data="input">cd ~/roses/&lt;suite-ID&gt;</terminal-line>
+    <terminal-line data="input" directory="~/roses/&lt;suite-ID&gt;">rose suite-gcontrol</terminal-line>
+    <img src="/assets/run_access_cm/Cylc_GUI_are.png" alt="Cylc GUI" imageTime="inf" loading="lazy">
+</terminal-window>
 
 ### STOP a suite
 To shutdown a suite in a safe manner, run the following command from within the suite directory:
@@ -676,81 +416,39 @@ There are two main ways to restart a suite:
         <div class="note">
             You may need to manually trigger failed tasks from the <i>Cylc</i> GUI.
         </div>
-        <div class="tabContents" label="workflow">
-            <!-- ARE / Gadi -->
-            <div>
-                <terminal-window lineDelay="50">
-                    <terminal-line data="input" lineDelay="300">cylc</terminal-line>
-                    <terminal-line data="input" lineDelay="300">cd ~/roses/&lt;suite-ID&gt;</terminal-line>
-                    <terminal-line data="input" directory="~/roses/&lt;suite-ID&gt;" lineDelay="300">rose suite-run --restart</terminal-line>
-                    <terminal-line>[INFO] export CYLC_VERSION=7.9.7</terminal-line>
-                    <terminal-line>[INFO] export ROSE_ORIG_HOST=&lt;gadi-cpu&gt;.nci.org.au</terminal-line>
-                    <terminal-line>[INFO] export ROSE_SITE=nci</terminal-line>
-                    <terminal-line>[INFO] export ROSE_VERSION=2019.01.2</terminal-line>
-                    <terminal-line>[INFO] delete: log/rose-suite-run.conf</terminal-line>
-                    <terminal-line>[INFO] symlink: rose-conf/&lt;timestamp&gt;-restart.conf <= log/rose-suite-run.conf</terminal-line>
-                    <terminal-line>[INFO] delete: log/rose-suite-run.version</terminal-line>
-                    <terminal-line>[INFO] symlink: rose-conf/&lt;timestamp&gt;-restart.version <= log/rose-suite-run.version</terminal-line>
-                    <terminal-line>[INFO] chdir: log/</terminal-line>
-                    <terminal-line>[INFO] &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;&thinsp;._.</terminal-line>
-                    <terminal-line>[INFO] &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;&thinsp;| |&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;The Cylc Suite Engine [7.9.7]</terminal-line>
-                    <terminal-line>[INFO] ._____._. ._| |_____.&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;Copyright (C) 2008-2019 NIWA</terminal-line>
-                    <terminal-line>[INFO] | .___| | | | | .___|&emsp;& British Crown (Met Office) & Contributors.</terminal-line>
-                    <terminal-line>[INFO] | !___| !_! | | !___. _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _</terminal-line>
-                    <terminal-line>[INFO] !_____!___. |_!_____! This program comes with ABSOLUTELY NO WARRANTY;</terminal-line>
-                    <terminal-line>[INFO] &emsp;&emsp;&emsp;&thinsp;.___! | &emsp;&emsp;&emsp;&emsp;&emsp;see `cylc warranty`. &thinsp;It is free software, you</terminal-line>
-                    <terminal-line>[INFO] &emsp;&emsp;&emsp;&thinsp;!_____! &emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;are welcome to redistribute it under certain</terminal-line>
-                    <terminal-line>[INFO]</terminal-line>
-                    <terminal-line>[INFO] *** listening on https://&lt;gadi-cpu&gt;.nci.org.au:&lt;port&gt;/ ***</terminal-line>
-                    <terminal-line>[INFO]</terminal-line>
-                    <terminal-line>[INFO] To view suite server program contact information:</terminal-line>
-                    <terminal-line>[INFO]  $ cylc get-suite-contact &lt;suite-ID&gt;</terminal-line>
-                    <terminal-line>[INFO]</terminal-line>
-                    <terminal-line>[INFO] Other ways to see if the suite is still running:</terminal-line>
-                    <terminal-line>[INFO]  $ cylc scan -n '&lt;suite-ID&gt;' &lt;gadi-cpu&gt;.nci.org.au</terminal-line>
-                    <terminal-line>[INFO]  $ cylc ping -v --host=&lt;gadi-cpu&gt;.nci.org.au &lt;suite-ID&gt;</terminal-line>
-                    <terminal-line>[INFO]  $ ps -opid,args &lt;PID&gt;  # on &lt;gadi-cpu&gt;.nci.org.au</terminal-line>
-                    <img src="/assets/run_access_cm/Cylc_GUI_are.png" alt="Cylc GUI" imageTime="inf" loading="lazy">
-                </terminal-window>
-            </div>
-            <!-- accessdev -->
-            <div>
-                <terminal-window lineDelay="50">
-                    <terminal-line data="input" lineDelay="300">cylc</terminal-line>
-                    <terminal-line data="input" lineDelay="300">cd ~/roses/&lt;suite-ID&gt;</terminal-line>
-                    <terminal-line data="input" directory="~/roses/&lt;suite-ID&gt;" lineDelay="300">rose suite-run --restart</terminal-line>
-                    <terminal-line>[INFO] export CYLC_VERSION=7.8.3</terminal-line>
-                    <terminal-line>[INFO] export ROSE_ORIG_HOST=accessdev.nci.org.au</terminal-line>
-                    <terminal-line>[INFO] export ROSE_SITE=</terminal-line>
-                    <terminal-line>[INFO] export ROSE_VERSION=2019.01.2</terminal-line>
-                    <terminal-line>[INFO] delete: log/rose-suite-run.conf</terminal-line>
-                    <terminal-line>[INFO] symlink: rose-conf/&lt;timestamp&gt;-restart.conf <= log/rose-suite-run.conf</terminal-line>
-                    <terminal-line>[INFO] delete: log/rose-suite-run.version</terminal-line>
-                    <terminal-line>[INFO] symlink: rose-conf/&lt;timestamp&gt;-restart.version <= log/rose-suite-run.version</terminal-line>
-                    <terminal-line>[INFO] chdir: log/</terminal-line>
-                    <terminal-line>[INFO] &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;&thinsp;._.</terminal-line>
-                    <terminal-line>[INFO] &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;&thinsp;| |&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;The Cylc Suite Engine [7.8.3]</terminal-line>
-                    <terminal-line>[INFO] ._____._. ._| |_____.&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;Copyright (C) 2008-2019 NIWA</terminal-line>
-                    <terminal-line>[INFO] | .___| | | | | .___|&emsp;& British Crown (Met Office) & Contributors.</terminal-line>
-                    <terminal-line>[INFO] | !___| !_! | | !___. _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _</terminal-line>
-                    <terminal-line>[INFO] !_____!___. |_!_____! This program comes with ABSOLUTELY NO WARRANTY;</terminal-line>
-                    <terminal-line>[INFO] &emsp;&emsp;&emsp;&thinsp;.___! | &emsp;&emsp;&emsp;&emsp;&emsp;see `cylc warranty`. &thinsp;It is free software, you</terminal-line>
-                    <terminal-line>[INFO] &emsp;&emsp;&emsp;&thinsp;!_____! &emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;are welcome to redistribute it under certain</terminal-line>
-                    <terminal-line>[INFO]</terminal-line>
-                    <terminal-line>[INFO] *** listening on https://accessdev.nci.org.au:&lt;port&gt;/ ***</terminal-line>
-                    <terminal-line>[INFO]</terminal-line>
-                    <terminal-line>[INFO] To view suite server program contact information:</terminal-line>
-                    <terminal-line>[INFO]  $ cylc get-suite-contact &lt;suite-ID&gt;</terminal-line>
-                    <terminal-line>[INFO]</terminal-line>
-                    <terminal-line>[INFO] Other ways to see if the suite is still running:</terminal-line>
-                    <terminal-line>[INFO]  $ cylc scan -n '&lt;suite-ID&gt;' accessdev.nci.org.au</terminal-line>
-                    <terminal-line>[INFO]  $ cylc ping -v --host=accessdev.nci.org.au &lt;suite-ID&gt;</terminal-line>
-                    <terminal-line>[INFO]  $ ps -opid,args &lt;PID&gt;  # on accessdev.nci.org.au</terminal-line>
-                    <img src="/assets/run_access_cm/Cylc_GUI.png" alt="Cylc GUI" imageTime="inf" loading="lazy">
-                </terminal-window>
-            </div>
-        </div>
-        <!-- End of tab content -->
+        <terminal-window lineDelay="50">
+            <terminal-line data="input" lineDelay="300">cylc</terminal-line>
+            <terminal-line data="input" lineDelay="300">cd ~/roses/&lt;suite-ID&gt;</terminal-line>
+            <terminal-line data="input" directory="~/roses/&lt;suite-ID&gt;" lineDelay="300">rose suite-run --restart</terminal-line>
+            <terminal-line>[INFO] export CYLC_VERSION=7.9.7</terminal-line>
+            <terminal-line>[INFO] export ROSE_ORIG_HOST=&lt;gadi-cpu&gt;.nci.org.au</terminal-line>
+            <terminal-line>[INFO] export ROSE_SITE=nci</terminal-line>
+            <terminal-line>[INFO] export ROSE_VERSION=2019.01.2</terminal-line>
+            <terminal-line>[INFO] delete: log/rose-suite-run.conf</terminal-line>
+            <terminal-line>[INFO] symlink: rose-conf/&lt;timestamp&gt;-restart.conf <= log/rose-suite-run.conf</terminal-line>
+            <terminal-line>[INFO] delete: log/rose-suite-run.version</terminal-line>
+            <terminal-line>[INFO] symlink: rose-conf/&lt;timestamp&gt;-restart.version <= log/rose-suite-run.version</terminal-line>
+            <terminal-line>[INFO] chdir: log/</terminal-line>
+            <terminal-line>[INFO] &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;&thinsp;._.</terminal-line>
+            <terminal-line>[INFO] &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;&thinsp;| |&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;The Cylc Suite Engine [7.9.7]</terminal-line>
+            <terminal-line>[INFO] ._____._. ._| |_____.&emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;Copyright (C) 2008-2019 NIWA</terminal-line>
+            <terminal-line>[INFO] | .___| | | | | .___|&emsp;& British Crown (Met Office) & Contributors.</terminal-line>
+            <terminal-line>[INFO] | !___| !_! | | !___. _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _</terminal-line>
+            <terminal-line>[INFO] !_____!___. |_!_____! This program comes with ABSOLUTELY NO WARRANTY;</terminal-line>
+            <terminal-line>[INFO] &emsp;&emsp;&emsp;&thinsp;.___! | &emsp;&emsp;&emsp;&emsp;&emsp;see `cylc warranty`. &thinsp;It is free software, you</terminal-line>
+            <terminal-line>[INFO] &emsp;&emsp;&emsp;&thinsp;!_____! &emsp;&emsp;&emsp;&emsp;&emsp;&thinsp;are welcome to redistribute it under certain</terminal-line>
+            <terminal-line>[INFO]</terminal-line>
+            <terminal-line>[INFO] *** listening on https://&lt;gadi-cpu&gt;.nci.org.au:&lt;port&gt;/ ***</terminal-line>
+            <terminal-line>[INFO]</terminal-line>
+            <terminal-line>[INFO] To view suite server program contact information:</terminal-line>
+            <terminal-line>[INFO]  $ cylc get-suite-contact &lt;suite-ID&gt;</terminal-line>
+            <terminal-line>[INFO]</terminal-line>
+            <terminal-line>[INFO] Other ways to see if the suite is still running:</terminal-line>
+            <terminal-line>[INFO]  $ cylc scan -n '&lt;suite-ID&gt;' &lt;gadi-cpu&gt;.nci.org.au</terminal-line>
+            <terminal-line>[INFO]  $ cylc ping -v --host=&lt;gadi-cpu&gt;.nci.org.au &lt;suite-ID&gt;</terminal-line>
+            <terminal-line>[INFO]  $ ps -opid,args &lt;PID&gt;  # on &lt;gadi-cpu&gt;.nci.org.au</terminal-line>
+            <img src="/assets/run_access_cm/Cylc_GUI_are.png" alt="Cylc GUI" imageTime="inf" loading="lazy">
+        </terminal-window>
     </li>
     <br>  
     <li>
@@ -802,62 +500,30 @@ This directory contains two subdirectories:
     </li>
 </ul>
 For the atmospheric output data, the files are typically a <a href = "https://code.metoffice.gov.uk/doc/um/latest/papers/umdp_F03.pdf" target="_blank">UM fieldsfile</a> or netCDF file, formatted as <code>&lt;suite-name&gt;a.p&lt;output-stream-identifier&gt;&lt;year&gt;&lt;month-string&gt;</code>.
-<br>
-<div class="tabContents" label="workflow">
-    <!-- ARE / Gadi -->
-    <div>
-        For the <code>u-cy339</code> suite in this example, the <code>atm</code> directory contains:
-        <terminal-window>
-            <terminal-line data="input">cd /scratch/&lt;$PROJECT&gt;/&lt;$USER&gt;/archive</terminal-line>
-            <terminal-line data="input" directory="/scratch/&lt;$PROJECT&gt;/&lt;$USER&gt;/archive">ls</terminal-line>
-            <terminal-line class="ls-output-format">cy339 &lt;other-suite-name&gt; &lt;other-suite-name&gt;</terminal-line>
-            <terminal-line data="input" directory="/scratch/&lt;$PROJECT&gt;/&lt;$USER&gt;/archive">cd cy339</terminal-line>
-            <terminal-line data="input" directory="/scratch/&lt;$PROJECT&gt;/&lt;$USER&gt;/archive/cy339">ls</terminal-line>
-            <terminal-line class="ls-output-format">history restart</terminal-line>
-            <terminal-line data="input" directory="/scratch/&lt;$PROJECT&gt;/&lt;$USER&gt;/archive/cy339">ls history/atm</terminal-line>
-            <terminal-line class="ls-output-format">cy339a.pd0950apr.nc cy339a.pd0950aug.nc cy339a.pd0950dec.nc cy339a.pd0950feb.nc cy339a.pd0950jan.nc cy339a.pd0950jul.nc cy339a.pd0950jun.nc cy339a.pd0950mar.nc cy339a.pd0950may.nc cy339a.pd0950nov.nc cy339a.pd0950oct.nc cy339a.pd0950sep.nc cy339a.pd0951apr.nc cy339a.pd0951aug.nc cy339a.pd0951dec.nc cy339a.pm0950apr.nc cy339a.pm0950aug.nc cy339a.pm0950dec.nc cy339a.pm0950feb.nc cy339a.pm0950jan.nc cy339a.pm0950jul.nc cy339a.pm0950jun.nc cy339a.pm0950mar.nc cy339a.pm0950may.nc cy339a.pm0950nov.nc cy339a.pm0950oct.nc cy339a.pm0950sep.nc cy339a.pm0951apr.nc cy339a.pm0951aug.nc cy339a.pm0951dec.nc netCDF</terminal-line>
-        </terminal-window>
-    </div>
-    <!-- accessdev -->
-    <div>
-        For the <code>u-br565</code> suite in this example, the <code>atm</code> directory contains:
-        <terminal-window>
-            <terminal-line data="input">cd /scratch/&lt;$PROJECT&gt;/&lt;$USER&gt;/archive</terminal-line>
-            <terminal-line data="input" directory="/scratch/&lt;$PROJECT&gt;/&lt;$USER&gt;/archive">ls</terminal-line>
-            <terminal-line class="ls-output-format">br565 &lt;other-suite-name&gt; &lt;other-suite-name&gt;</terminal-line>
-            <terminal-line data="input" directory="/scratch/&lt;$PROJECT&gt;/&lt;$USER&gt;/archive">cd br565</terminal-line>
-            <terminal-line data="input" directory="/scratch/&lt;$PROJECT&gt;/&lt;$USER&gt;/archive/br565">ls</terminal-line>
-            <terminal-line class="ls-output-format">history restart</terminal-line>
-            <terminal-line data="input" directory="/scratch/&lt;$PROJECT&gt;/&lt;$USER&gt;/archive/br565">ls history/atm</terminal-line>
-            <terminal-line class="ls-output-format">br565a.pd0950apr.nc br565a.pd0950aug.nc br565a.pd0950dec.nc br565a.pd0950feb.nc br565a.pd0950jan.nc br565a.pd0950jul.nc br565a.pd0950jun.nc br565a.pd0950mar.nc br565a.pd0950may.nc br565a.pd0950nov.nc br565a.pd0950oct.nc br565a.pd0950sep.nc br565a.pd0951apr.nc br565a.pd0951aug.nc br565a.pd0951dec.nc br565a.pm0950apr.nc br565a.pm0950aug.nc br565a.pm0950dec.nc br565a.pm0950feb.nc br565a.pm0950jan.nc br565a.pm0950jul.nc br565a.pm0950jun.nc br565a.pm0950mar.nc br565a.pm0950may.nc br565a.pm0950nov.nc br565a.pm0950oct.nc br565a.pm0950sep.nc br565a.pm0951apr.nc br565a.pm0951aug.nc br565a.pm0951dec.nc netCDF</terminal-line>
-        </terminal-window>
-    </div>
-</div>
-<!-- End of tab content -->
+
+For the <code>u-cy339</code> suite in this example, the <code>atm</code> directory contains:
+<terminal-window>
+    <terminal-line data="input">cd /scratch/&lt;$PROJECT&gt;/&lt;$USER&gt;/archive</terminal-line>
+    <terminal-line data="input" directory="/scratch/&lt;$PROJECT&gt;/&lt;$USER&gt;/archive">ls</terminal-line>
+    <terminal-line class="ls-output-format">cy339 &lt;other-suite-name&gt; &lt;other-suite-name&gt;</terminal-line>
+    <terminal-line data="input" directory="/scratch/&lt;$PROJECT&gt;/&lt;$USER&gt;/archive">cd cy339</terminal-line>
+    <terminal-line data="input" directory="/scratch/&lt;$PROJECT&gt;/&lt;$USER&gt;/archive/cy339">ls</terminal-line>
+    <terminal-line class="ls-output-format">history restart</terminal-line>
+    <terminal-line data="input" directory="/scratch/&lt;$PROJECT&gt;/&lt;$USER&gt;/archive/cy339">ls history/atm</terminal-line>
+    <terminal-line class="ls-output-format">cy339a.pd0950apr.nc cy339a.pd0950aug.nc cy339a.pd0950dec.nc cy339a.pd0950feb.nc cy339a.pd0950jan.nc cy339a.pd0950jul.nc cy339a.pd0950jun.nc cy339a.pd0950mar.nc cy339a.pd0950may.nc cy339a.pd0950nov.nc cy339a.pd0950oct.nc cy339a.pd0950sep.nc cy339a.pd0951apr.nc cy339a.pd0951aug.nc cy339a.pd0951dec.nc cy339a.pm0950apr.nc cy339a.pm0950aug.nc cy339a.pm0950dec.nc cy339a.pm0950feb.nc cy339a.pm0950jan.nc cy339a.pm0950jul.nc cy339a.pm0950jun.nc cy339a.pm0950mar.nc cy339a.pm0950may.nc cy339a.pm0950nov.nc cy339a.pm0950oct.nc cy339a.pm0950sep.nc cy339a.pm0951apr.nc cy339a.pm0951aug.nc cy339a.pm0951dec.nc netCDF</terminal-line>
+</terminal-window>
 
 ### Restart files
 The restart files can be found in the <code>/scratch/$PROJECT/$USER/archive/&lt;suite-name&gt;/restart</code> directory, where they are categorised according to model components (similar to the <code>history</code> folder above).
 <br>
 The atmospheric restart files, which are <a href = "https://code.metoffice.gov.uk/doc/um/latest/papers/umdp_F03.pdf" target="_blank">UM fieldsfiles</a>, are formatted as <code>&lt;suite-name&gt;a.da&lt;year&gt;&lt;month&gt;&lt;day&gt;_00</code>.
-<div class="tabContents" label="workflow">
-    <!-- ARE / Gadi -->
-    <div>
-        For the <code>u-cy339</code> suite in this example, the <code>atm</code> directory contains:
-        <terminal-window>
-            <terminal-line data="input">ls /scratch/&lt;$PROJECT&gt;/&lt;$USER&gt;/archive/cy339/restart/atm</terminal-line>
-            <terminal-line class="ls-output-format">cy339a.da09500201_00 cy339a.da09510101_00 cy339.xhist-09500131 cy339.xhist-09501231 </terminal-line>
-        </terminal-window>
-    </div>
-    <!-- accessdev -->
-    <div>
-        For the <code>u-br565</code> suite in this example, the <code>atm</code> directory contains:
-        <terminal-window>
-            <terminal-line data="input">ls /scratch/&lt;$PROJECT&gt;/&lt;$USER&gt;/archive/br565/restart/atm</terminal-line>
-            <terminal-line class="ls-output-format">br565a.da09500201_00 br565a.da09510101_00 br565.xhist-09500131 br565.xhist-09501231 </terminal-line>
-        </terminal-window>
-    </div>
-</div>
-<!-- End of the tab content -->
+
+For the <code>u-cy339</code> suite in this example, the <code>atm</code> directory contains:
+<terminal-window>
+    <terminal-line data="input">ls /scratch/&lt;$PROJECT&gt;/&lt;$USER&gt;/archive/cy339/restart/atm</terminal-line>
+    <terminal-line class="ls-output-format">cy339a.da09500201_00 cy339a.da09510101_00 cy339.xhist-09500131 cy339.xhist-09501231 </terminal-line>
+</terminal-window>
+
 Files formatted as <code>&lt;suite-name&gt;a.xhist-&lt;year&gt;&lt;month&gt;&lt;day&gt;</code> contain metadata information.
 
 <br>

--- a/docs/models/run-a-model/run-access-cm.md
+++ b/docs/models/run-a-model/run-access-cm.md
@@ -90,7 +90,7 @@ To open the terminal, click on the black terminal icon at the top of the window.
 <img src="/assets/run_access_cm/open_are_vdi_terminal.gif" alt="Open ARE VDI terminal" class="example-img" loading="lazy"/>
 
 ## Setup {{ model }} persistent session
-To support the use of long-running processes (such as ACCESS models runs), NCI provides a service on <i>Gadi</i> called <a href="https://opus.nci.org.au/display/Help/Persistent+Sessions" target="_blank">persistent sessions</a>.
+To support the use of long-running processes, such as ACCESS models runs, NCI provides a service on <i>Gadi</i> called <a href="https://opus.nci.org.au/display/Help/Persistent+Sessions" target="_blank">persistent sessions</a>.
 
 To run {{ model }}, you need to start a persistent session and set it as the target session for the model run.
 
@@ -104,7 +104,7 @@ If you want to assign a different project to the persistent session, use the opt
 <pre><code>persistent-sessions start -p &lt;project&gt; &lt;name&gt;</code></pre>
 
 <div class="note">
-    The project assigned to a persistent session does not have to be necessarily the same to the project used to run {{ model }} configuration, but needs to have allocated <i>Service Units</i> (SU).
+    While the project assigned to a persistent session does not have to be the same as the project used to run the {{ model }} configuration, it does need to have allocated <i>Service Units</i> (SU).
     <br>
     For more information, check how to <a href="/getting_started/first_steps#join-relevant-nci-projects">Join relevant NCI projects</a>.
 </div>
@@ -114,7 +114,7 @@ If you want to assign a different project to the persistent session, use the opt
     <terminal-line data="output">&emsp;ssh &lt;name&gt;.&lt;$USER&gt;.&lt;project&gt;.ps.gadi.nci.org.au</terminal-line>
 </terminal-window>
 
-To list all the active persistent sessions run:
+To list all active persistent sessions run:
 <pre><code>persistent-sessions list</code></pre>
 
 <terminal-window data="input">
@@ -124,7 +124,7 @@ To list all the active persistent sessions run:
 </terminal-window>
 
 
-The full name of a newly created persistent session is formatted as: 
+The label of a newly-created persistent session has the following format: 
 <br>
 <code>&lt;name&gt;.&lt;$USER&gt;.&lt;project&gt;.ps.gadi.nci.org.au</code>.
 
@@ -132,23 +132,23 @@ The full name of a newly created persistent session is formatted as:
 
 After starting the persistent session, it is essential to assign it to the {{ model }} run.
 <br>
-The easiest way to do so, is to insert the persistent session full name into the file <code>~/.persistent-sessions/cylc-session</code>.
+The easiest way to do this, is to insert the persistent session label into the file <code>~/.persistent-sessions/cylc-session</code>.
 <br>
 You can do it manually, or by running the following command:
 
 <pre><code>cat > ~/.persistent-sessions/cylc-session <<< &lt;name&gt;.&lt;$USER&gt;.&lt;project&gt;.ps.gadi.nci.org.au</code></pre>
 
-For example, if the user <code>dm5220</code> started a persistent session named <code>cylc</code>, under the project <code>tm70</code>, the command will be:
+For example, if the user <code>abc123</code> started a persistent session named <code>cylc</code>, under the project <code>xy00</code>, the command will be:
 
 <terminal-window data="input">
-    <terminal-line>cat > ~/.persistent-sessions/cylc-session <<< cylc.dm5220.tm70.ps.gadi.nci.org.au</terminal-line>
+    <terminal-line>cat > ~/.persistent-sessions/cylc-session <<< cylc.abc123.xy00.ps.gadi.nci.org.au</terminal-line>
     <terminal-line data="input" linedelay="1000">cat ~/.persistent-sessions/cylc-session</terminal-line>
-    <terminal-line data="output">cylc.dm5220.tm70.ps.gadi.nci.org.au</terminal-line>
+    <terminal-line data="output">cylc.abc123.xy00.ps.gadi.nci.org.au</terminal-line>
 </terminal-window>
 
-For more information on how to specify the target session, check <a href="https://opus.nci.org.au/display/DAE/Run+Cylc7+Suites#RunCylc7Suites-SpecifyTargetSession" target="_blank">Specify Target Session on Cylc7 Suites</a>.
+For more information on how to specify the target session, check <a href="https://opus.nci.org.au/display/DAE/Run+Cylc7+Suites#RunCylc7Suites-SpecifyTargetSession" target="_blank">Specify Target Session with Cylc7 Suites</a>.
 <div class="note">
-    You can concurrently submit multiple {{ model }} runs using the same persistent session, without the need to start another one. Therefore, the process of specifying the target persistent session for {{ model }} can potentially be done only once.
+    You can simultaneously submit multiple {{ model }} runs using the same persistent session without needing to start a new one. Hence, the process of specifying the target persistent session for {{ model }} should only need to be done once.
     <br>
     After specifying the {{ model }} target persistent session the first time, to run {{ model }} you just have to make sure to have an active persistent session named like the {{ model }} target persistent session.
 </div>
@@ -191,9 +191,9 @@ module load cylc7/23.09</code></pre>
         </terminal-window>
     </li>
     <div class="note">
-        Make sure to load a version of <i>Cylc</i> >= <code>23.09</code>, as earlier versions do not support the persistent sessions workflow.
+        Make sure to load a version of <i>Cylc</i> >= <code>23.09</code> as earlier versions do not support the persistent sessions workflow.
         <br>
-        Also, before loading the <i>Cylc</i> module, make sure to have started a persistent session and to have assigned it to the {{ model }} workflow. For more information about these steps, check <a href="{{ '#setup-%s-persistent-session'%model.lower() }}">Setup {{ model }} persistent session</a>.
+        Also, before loading the <i>Cylc</i> module, make sure to have started a persistent session and assigned it to the {{ model }} workflow. For more information about these steps, check <a href="{{ '#setup-%s-persistent-session'%model.lower() }}">Setup {{ model }} persistent session</a>.
     </div>
     <li>
         <b>MOSRS authentication</b>
@@ -614,7 +614,7 @@ Files formatted as <code>&lt;suite-name&gt;a.xhist-&lt;year&gt;&lt;month&gt;&lt;
 ## Port suites from accessdev
 <i>accessdev</i> was the server used for {{ model }} run submission workflow before the update to persistent sessions.
 <br>
-If you have a suite that was running on <i>accessdev</i>, you can run it on persistent sessions by doing the following steps:
+If you have a suite that was running on accessdev, you can run it using persistent sessions by carrying out the following steps:
 
 <ol>
     <li>

--- a/docs/models/run-a-model/run-access-cm.md
+++ b/docs/models/run-a-model/run-access-cm.md
@@ -5,7 +5,7 @@
     <br>
     If you are an <i>accessdev</i> user, make sure you are a member of <a href="https://my.nci.org.au/mancini/project/hr22/join" target="_blank">hr22</a> and <a href="https://my.nci.org.au/mancini/project/ki32/join" target="_blank">ki32</a> projects.
     <br>
-    Then, refer to instructions on how to <a href="{{ '#set-up-%s-persistent-session'%model.lower() }}">set up persistent session worflow for {{ model }}</a>, and how to <a href="#port-suites-from-accessdev">port suites from accessdev</a>.
+    Then, refer to instructions on how to <a href="{{ '#set-up-%s-persistent-session'%model.lower() }}">Set up persistent session worflow for {{ model }}</a>, and how to <a href="#port-suites-from-accessdev">port suites from accessdev</a>.
 </div>
 ## Prerequisites
 ### General prerequisites
@@ -42,7 +42,7 @@ If you are unsure whether {{ model }} is the right choice for your experiment, t
 
 --------------------------------------------
 ## Set up an ARE VDI Desktop (optional)
-To skip this step and instead run {{ model }} from <i>Gadi</i> login node, refer to instructions on how to <a href="{{ '#set-up-%s-persistent-session'%model.lower() }}">set up {{ model }} persistent session</a>.
+To skip this step and instead run {{ model }} from <i>Gadi</i> login node, refer to instructions on how to <a href="{{ '#set-up-%s-persistent-session'%model.lower() }}">Set up {{ model }} persistent session</a>.
 
 ### Launch ARE VDI Session
 Go to the <a href="https://are.nci.org.au/pun/sys/dashboard/batch_connect/sys/desktop_vnc/ncigadi/session_contexts/new" target="_blank">ARE VDI</a> page and launch a session with the following entries:
@@ -134,13 +134,13 @@ The label of a newly-created persistent session has the following format:
 
 After starting the persistent session, it is essential to assign it to the {{ model }} run.
 <br>
-The easiest way to do this, is to insert the persistent session label into the file <code>~/.persistent-sessions/cylc-session</code>.
+The easiest way to do this is to insert the persistent session label into the file <code>~/.persistent-sessions/cylc-session</code>.
 <br>
 You can do it manually, or by running the following command:
 
 <pre><code>cat > ~/.persistent-sessions/cylc-session <<< &lt;name&gt;.&lt;$USER&gt;.&lt;project&gt;.ps.gadi.nci.org.au</code></pre>
 
-For example, if the user <code>abc123</code> started a persistent session named <code>cylc</code>, under the project <code>xy00</code>, the command will be:
+For example, if the user <code>abc123</code> started a persistent session named <code>cylc</code> under the project <code>xy00</code>, the command will be:
 
 <terminal-window data="input">
     <terminal-line>cat > ~/.persistent-sessions/cylc-session <<< cylc.abc123.xy00.ps.gadi.nci.org.au</terminal-line>
@@ -148,11 +148,11 @@ For example, if the user <code>abc123</code> started a persistent session named 
     <terminal-line data="output">cylc.abc123.xy00.ps.gadi.nci.org.au</terminal-line>
 </terminal-window>
 
-For more information on how to specify the target session, check <a href="https://opus.nci.org.au/display/DAE/Run+Cylc7+Suites#RunCylc7Suites-SpecifyTargetSession" target="_blank">Specify Target Session with Cylc7 Suites</a>.
+For more information on how to specify the target session, refer to <a href="https://opus.nci.org.au/display/DAE/Run+Cylc7+Suites#RunCylc7Suites-SpecifyTargetSession" target="_blank">Specify Target Session with Cylc7 Suites</a>.
 <div class="note">
     You can simultaneously submit multiple {{ model }} runs using the same persistent session without needing to start a new one. Hence, the process of specifying the target persistent session for {{ model }} should only need to be done once.
     <br>
-    After specifying the {{ model }} target persistent session the first time, to run {{ model }} you just have to make sure to have an active persistent session named like the {{ model }} target persistent session.
+    After specifying the {{ model }} target persistent session the first time, to run {{ model }} you just need to make sure to have an active persistent session named like the {{ model }} target persistent session.
 </div>
 
 ### Terminate a persistent session
@@ -168,7 +168,7 @@ To stop a persistent session, run:
 <br>
 Each {{ model }} suite has a <code>suite-ID</code> in the format <code>u-&lt;suite-name&gt;</code>, where <code>&lt;suite-name&gt;</code> is a unique identifier.
 <br>
-For this example you can use <code>u-cy339</code>, which is a preindustrial experiment suite.
+For this example you can use <code>u-cy339</code>, which is a pre-industrial experiment suite.
 <br>
 Typically, an existing suite is copied and then edited as needed for a particular run.
 
@@ -193,9 +193,9 @@ module load cylc7/23.09</code></pre>
         </terminal-window>
     </li>
     <div class="note">
-        Make sure to load a version of <i>Cylc</i> >= <code>23.09</code> as earlier versions do not support the persistent sessions workflow.
+        Make sure to load <i>Cylc</i> version <code>23.09</code> (or later), as earlier versions do not support the persistent sessions workflow.
         <br>
-        Also, before loading the <i>Cylc</i> module, make sure to have started a persistent session and assigned it to the {{ model }} workflow. For more information about these steps, check <a href="{{ '#set-up-%s-persistent-session'%model.lower() }}">Set up {{ model }} persistent session</a>.
+        Also, before loading the <i>Cylc</i> module, make sure to have started a persistent session and assigned it to the {{ model }} workflow. For more information about these steps, refer to instructions on how to <a href="{{ '#set-up-%s-persistent-session'%model.lower() }}">Set up {{ model }} persistent session</a>.
     </div>
     <li>
         <b>MOSRS authentication</b>
@@ -624,7 +624,7 @@ If you have a suite that was running on accessdev, you can run it using persiste
         <br>
         To set the correct SSH configuration for <i>Cylc</i>, some SSH keys need to be created in the <code>~/.ssh</code> directory.
         <br>
-        To create the needed SSH keys, run the following command:
+        To create the required SSH keys, run the following command:
         <pre><code>/g/data/hr22/bin/gadi-cylc-setup-ps -y</code></pre>
         <div class="note">
             You only need to run this initialisation step once.
@@ -635,7 +635,7 @@ If you have a suite that was running on accessdev, you can run it using persiste
         <br>
         To enable <i>Cylc</i> to submit PBS jobs directly from the persistent session, the suite configuration should have its <code>host</code> set as <code>localhost</code>.
         <br>
-        You can manually set all occurrencies of <code>host</code> to <code>localhost</code> in the suite configuration files. 
+        You can manually set all occurrences of <code>host</code> to <code>localhost</code> in the suite configuration files. 
         <br>
         Alternatively, you can run the following command in the suite folder:
         <pre><code>grep -rl --exclude-dir=.svn "host\s*=" . | xargs sed -i 's/\(host\s*=\s*\).*/\1localhost/g'</code></pre>
@@ -643,11 +643,9 @@ If you have a suite that was running on accessdev, you can run it using persiste
     <li>
         <b>Add gdata/hr22 and gdata/ki32 in the PBS storage directives</b>
         <br>
-        The persistent sessions workflow uses files in the <code>hr22</code> and <code>ki32</code> project folders on <i>Gadi</i>. 
+        As the persistent sessions workflow uses files in the <code>hr22</code> and <code>ki32</code> project folders on <i>Gadi</i>, the respective folders need to be added to the <code>storage</code> directive in the suite configuration files.
         <br>
-        Therefore, the respective folders need to be added to the <code>storage</code> directive in the suite configuration files.
-        <br>
-        You can do this manually, or run the following command in the suite folder:
+        You can do this manually or run the following command from within the suite directory:
         <pre><code>grep -rl --exclude-dir=.svn "\-l\s*storage\s*=" . | xargs sed -i '/\-l\s*storage\s*=\s*.*gdata\/hr22.*/! s/\(\-l\s*storage\s*=\s*.*\)/\1+gdata\/hr22/g ; /\-l\s*storage\s*=\s*.*gdata\/ki32.*/! s/\(\-l\s*storage\s*=\s*.*\)/\1+gdata\/ki32/g'</code></pre>
     </li>
 </ol>


### PR DESCRIPTION
Updated 'How to run ACCESS-CM' page with the new persistent session workflow.
Completed removed accessdev workflow and added some instructions to try and port a suite from accessdev to persistent sessions.