### PR TITLE
Add warning for bug with ACCESS-ESM1.5 configurations

### DIFF
--- a/docs/models/run-a-model/run-access-esm.md
+++ b/docs/models/run-a-model/run-access-esm.md
@@ -1,6 +1,12 @@
 {% set model = "ACCESS-ESM" %}
 [PBS job]: https://opus.nci.org.au/display/Help/4.+PBS+Jobs
 
+!!! bug
+    There is a known issue with the {{ model }} configurations currently set up in the GitHub repository below.
+    {{ model }} configurations are currently being updated and an ACCESS-NRI release will come
+    in the following weeks.
+    If you encounter problems with the current guide in this page, consider asking for help on the [ACCESS-Hive Forum](https://forum.access-hive.org.au).
+
 # Run {{ model }}
 
 ## Prerequisites


### PR DESCRIPTION
Added 'bug' admonition at the top of the 'How to run ACCESS-ESM' page, to notify users about the known bug with current ACCESS-ESM1.5 configurations, and to inform them that an update is coming in the upcoming weeks.