### PR TITLE
Make syncing laboratory directory clearer before running ACCESS-OM

### DIFF
--- a/docs/models/run-a-model/run-access-om.md
+++ b/docs/models/run-a-model/run-access-om.md
@@ -127,7 +127,7 @@ _Payu_ also creates symbolic links in the _control_ directory pointing to the `a
 This design allows multiple self-resubmitting experiments that share common executables and input data to be run simultaneously.
 
 !!! admonition warning
-    The _laboratory_ directory might get deleted if not accessed for several days. To know more about how to preserve your experiment refer to [Syncing output data](#syncing-output-data).
+    Files on the `/scratch` drive, such as the _laboratory_ directory, might get deleted if not accessed for several days and the `/scratch` drive is limited in space. For these reasons, all model runs which are to be kept should be moved to `/g/data/` by enabling the _sync_ step in _payu_. To know more refer to [Syncing output data](#syncing-output-data).
 
 ### Run configuration
 
@@ -376,7 +376,7 @@ project: ol01
 ### Syncing output data
 
 The _laboratory_ directory is typically under the `/scratch` storage on _Gadi_, where [files are regularly deleted once they have been unaccessed for a period of time](https://opus.nci.org.au/pages/viewpage.action?pageId=156434436). For this reason climate model outputs need to be moved to a location with longer term storage.<br>
-On _Gadi_, this is typically under a project code on `/g/data`.  
+On _Gadi_, this is typically in a folder under a project code on `/g/data`.  
 
 _Payu_ has built-in support to sync outputs, restarts and a copy of the _control_ directory git history to another location.<br>
 This feature is controlled by the following section in the `config.yaml` file: 
@@ -390,7 +390,10 @@ sync:
       - '*.nc.*'
       - 'iceh.????-??-??.nc'
 ```
-To enable output syncing, change `enable` to `True`, and set `path` to a location on `/g/data`. 
+To enable syncing, change `enable` to `True`, and set `path` to a location on `/g/data`, where _payu_ will copy output and restart folders. A sensible `path` could be: `/g/data/$PROJECT/$USER/experiment_name/`.
+
+!!! admonition tip
+    The {{model}} default configurations include a [userscript](#userscripts) in the _sync_ step that concatenates daily history/diagnostic output from the Sea-Ice model (CICE5) into monthly files. This speeds up access and saves storage space, but will only run if _sync_ is enabled.
 
 ### Saving model restarts
 
@@ -535,8 +538,8 @@ A dictionary to run scripts or subcommands at various stages of a _payu_ submiss
 
 - `error` gets called if the model does not run correctly and returns an error code.
 - `run` gets called after the model execution, but prior to model output archive.
-- `sync` gets called at the start of the sync pbs job.
-
+- `sync` gets called at the start of the sync pbs job. For more information refer to [Syncing output data](#syncing-output-data).
+  
 For more information about specific `userscripts` fields, check the relevant section of [_payu_ Configuration Settings documentation](https://payu.readthedocs.io/en/latest/config.html#postprocessing).
 
 #### Miscellaneous

--- a/docs/models/run-a-model/run-access-om.md
+++ b/docs/models/run-a-model/run-access-om.md
@@ -126,6 +126,9 @@ _Payu_ also creates symbolic links in the _control_ directory pointing to the `a
 
 This design allows multiple self-resubmitting experiments that share common executables and input data to be run simultaneously.
 
+!!! admonition warning
+    The _laboratory_ directory might get deleted if not accessed for several days. To know more about how to preserve your experiment refer to [Syncing output data](#syncing-output-data).
+
 ### Run configuration
 
 To run {{ model }} configuration execute the following command from within the *control* directory:
@@ -308,6 +311,8 @@ This section describes how to modify {{ model }} configuration.<br>
 The modifications discussed in this section can change the way {{ model }} is run by _payu_, or how its specific [model components] are configured and coupled together.
 
 The `config.yaml` file located in the _control_ directory is the _Master Configuration_ file, which controls the general model configuration. It contains several parts, some of which it is more likely will need modification, and others which are rarely changed without having a deep understanding of how the model is configured.
+
+To find out more about configuration settings for the `config.yaml` file, refer to [how to configure your experiment with payu](https://payu.readthedocs.io/en/latest/config.html).
 
 ### Change run length
 
@@ -545,8 +550,6 @@ qsub_flags: -W umask=027
 env:
     UCX_LOG_LEVEL: 'error'
 ```
-
-To find out more about configuration settings for the `config.yaml` file, refer to [how to configure your experiment with payu](https://payu.readthedocs.io/en/latest/config.html).
 
 ### Edit a single {{ model }} component configuration
 


### PR DESCRIPTION
Following the suggestions raised in #699 I added a warning before the [Run configuration](https://access-hive.org.au/models/run-a-model/run-access-om/#run-configuration) paragraph to point to the syncing option.