### PR TITLE
Change ESM1.5 cice version to 4.1

### DIFF
--- a/docs/models/configurations/access-esm.md
+++ b/docs/models/configurations/access-esm.md
@@ -23,7 +23,7 @@ This means it can simulate both the physical climate and global biogeochemical c
 
 - **Ocean Biogeochemistry**: [WOMBAT](/models/model_components/bgc_ocean#wombat).
 
-- **Sea ice**: [CICE5.1.2](/models/model_components/sea-ice#cice5).<br>
+- **Sea ice**: [CICE4.1](/models/model_components/sea-ice#cice4).<br>
   Same grid as Ocean.
 
 - **Coupler**: [OASIS3-MCT](/models/model_components/coupler#oasis3-mct).

--- a/docs/models/model_components/sea-ice.md
+++ b/docs/models/model_components/sea-ice.md
@@ -6,17 +6,24 @@
 CICE is a numerical model for simulating the growth, melting and movement of polar sea ice. This software package was developed by researchers at [Los Alamos National Laboratory team](https://www.lanl.gov) and is currently managed by the [CICE Consortium](https://github.com/CICE-Consortium/About-Us/wiki), an international group of institutions formed to maintain and develop CICE in the public domain.
 
 ### Configurations that use CICE
-There are two CICE versions currently used in ACCESS models: [CICE5](https://github.com/CICE-Consortium/CICE-svn-trunk) and [CICE6](https://github.com/CICE-Consortium/CICE).
+There are three CICE versions currently used in ACCESS models:
+[CICE4](https://github.com/CICE-Consortium/CICE-svn-trunk/tree/svn/tags/release-4.1),  
+[CICE5](https://github.com/CICE-Consortium/CICE-svn-trunk) and [CICE6](https://github.com/CICE-Consortium/CICE).
 <!-- Tab labels -->
 <div class="tabLabels" label="CICE-versions">
+    <button id="cice4">CICE4</button>
     <button id="cice5">CICE5</button>
     <button id="cice6">CICE6</button>
 </div>
 <!-- Tab content -->
 <div class="tabContents" label="CICE-versions">
+     <!-- CICE4 -->
+    <div>
+        <p>CICE4 is used in <a href="/models/configurations/access-esm#access-esm15">ACCESS-ESM1.5</a> .</p>
+    </div>
     <!-- CICE5 -->
     <div>
-        <p>CICE5 is used in <a href="/models/configurations/access-cm#access-cm2">ACCESS-CM2</a>, <a href="/models/configurations/access-esm#access-esm15">ACCESS-ESM1.5</a> and <a href="/models/configurations/access-om#access-om2">ACCESS-OM2</a>.</p>
+        <p>CICE5 is used in <a href="/models/configurations/access-cm#access-cm2">ACCESS-CM2</a> and <a href="/models/configurations/access-om#access-om2">ACCESS-OM2</a>.</p>
     </div>
     <!-- CICE6 -->
     <div>


### PR DESCRIPTION
## Description

Corrects the CICE version in the [ACCESS-ESM
](https://access-hive.org.au/models/configurations/access-esm/)  and [se-ice](https://access-hive.org.au/models/model_components/sea-ice/) pages to version 4.1.

Fixes #700 



<!-- This is an html comment so these instructions are not visible in your pull request
Now, if you really want to make the ACCESS-Hive developers life easier, consider filling up what follows. 😍

The following sections create checkboxes that you can "tick-off" after you've created your pull request. They are intended to help you to ensure your pull request will be accepted as easily as possible.  

If you find this intimidating or you don't really know what some of those bullet points mean, then just delete everything from here onwards. 🫣
-->


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue, e.g. dead links)

## Checklist:

- [x] The new content is accessible and located in the appropriate section
- [x] My changes do not break navigation and do not generate new warnings
- [x] I have checked that the links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings
- [ ] I have chosen the correct tag for the level of [support provided](https://access-hive.org.au/#support)
