### PR TITLE
Add links to training materials

### DIFF
--- a/docs/community_resources/access_workshop_2024/training_materials.md
+++ b/docs/community_resources/access_workshop_2024/training_materials.md
@@ -1,4 +1,14 @@
-Links to other materials will be added here soon!
+## Training session materials
+
+[CMIP7 Evaluation Hackathon](https://access-nri.github.io/CMIP7_MED_Hackathon/) 
+
+[How to find and access datasets on NCI & handle large model output](https://github.com/ACCESS-NRI/training-day-2024-find-analyse-data)
+
+[Advanced git & GitHub best practices for software developers](https://github.com/ACCESS-NRI/training-day-2024-advanced_git)
+
+[Running model experiments with Payu and Git](https://forum.access-hive.org.au/t/running-model-experiments-with-payu-and-git/2285)
+
+[Running a high-resolution regional model using a two-level nest](https://github.com/ACCESS-NRI/training-day-2024-regional_model)
 
 
 


### PR DESCRIPTION
## Description

Adds links to all training materials on the Training Day page

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue, e.g. dead links)
- [x] New link / content

## Checklist:

- [x] The new content is accessible and located in the appropriate section
- [x] My changes do not break navigation and do not generate new warnings
- [x] I have checked that the links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings
- [ ] I have chosen the correct tag for the level of [support provided](https://access-hive.org.au/#support)

