### PR TITLE
fix auto merge

### DIFF
--- a/.github/workflows/automatic_merge.yml
+++ b/.github/workflows/automatic_merge.yml
@@ -10,14 +10,13 @@ on:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@master
       with:
-        ref: main 
+        ref: main
         fetch-depth: 0
+        token: ${{ secrets.ADMIN_TOKEN }}
     
     - name: Import GPG settings
       uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0

--- a/.github/workflows/automatic_merge.yml
+++ b/.github/workflows/automatic_merge.yml
@@ -5,6 +5,7 @@ on:
     # Run every Monday at 03:09 (AEDT)
     # AEDT is UTC+10 --> Monday at 03:09 AEDT is Sunday at 17:09 UTC
     - cron: "9 17 * * SUN"
+  push:
 
 jobs:
   auto-merge:
@@ -32,6 +33,7 @@ jobs:
     
     - name: Merge development to main
       run: |
+        git config --list
         git merge --no-ff -X theirs origin/development -m "Automatically merge 'development' to 'main'.
         Merge commit issued by the automatic_merge workflow."
         git push origin main

--- a/.github/workflows/automatic_merge.yml
+++ b/.github/workflows/automatic_merge.yml
@@ -5,11 +5,17 @@ on:
     # Run every Monday at 03:09 (AEDT)
     # AEDT is UTC+10 --> Monday at 03:09 AEDT is Sunday at 17:09 UTC
     - cron: "9 17 * * SUN"
-  push:
 
 jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check links
+      uses: ./.github/workflows/check_links.yml
+
   auto-merge:
     runs-on: ubuntu-latest
+    # needs: check-links
     steps:
     - name: Checkout repo
       uses: actions/checkout@master

--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -6,25 +6,21 @@ on:
       - opened
       - reopened
       - synchronize
-  schedule: 
-    # Run every Monday at 03:07 (AEDT)
-    # AEDT is UTC+10 --> Monday at 03:07 AEDT is Sunday at 17:07 UTC
-    - cron: "7 17 * * SUN"
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   link-check:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout main repo
-      if: ${{github.event_name == 'schedule'}}
+      if: ${{github.event_name == 'pull_request'}}
+      uses: actions/checkout@master
+
+    - name: Checkout repo
+      if: ${{github.event_name != 'pull_request'}}
       uses: actions/checkout@master
       with:
         ref: main
-
-    - name: Checkout repo
-      if: ${{github.event_name != 'schedule'}}
-      uses: actions/checkout@master
     
     - name: Link checker
       uses: lycheeverse/lychee-action@2b973e86fc7b1f6b36a93795fe2c9c6ae1118621 #v1.10.0

--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/checkout@master
     
     - name: Link checker
-      uses: lycheeverse/lychee-action@v1.10.0
+      uses: lycheeverse/lychee-action@2b973e86fc7b1f6b36a93795fe2c9c6ae1118621 #v1.10.0
       with:
         fail: true
         args: --config .github/workflows/lychee-config.toml './docs/**/*.md' './docs/**/*.html'


### PR DESCRIPTION
- [x] Changed reference of lychee-action in check_links workflow to specific commit rather than version number
- [x] Added print of config options to automatic_merge.yml workflow.
- [x] Added ADMIN_TOKEN to checkout, to allow bypassing branch protections.
- [x] Added check links as job required for auto-merge (this requirement is turned-off until the website links have been updated)
