### PR TITLE
Add link to preset output tables to Run ACCESS ESM1.5 tutorial

### DIFF
--- a/docs/models/run-a-model/run-access-esm.md
+++ b/docs/models/run-a-model/run-access-esm.md
@@ -643,7 +643,7 @@ To modify these options please refer to the User Guide of the respective model c
 ### Controlling model output
 Selecting the variables to save from a simulation can be a balance between enabling future analysis and minimising storage requirements. The choice and frequency of variables saved by each model can be configured from within each submodel's _control_ directory. 
 
-Each submodel's _control_ directory contains _detailed_ and _standard_ presets for controlling the output, located in the `diagnostic_profiles` subdirectories (e.g. `~/access-esm/preindustrial+concentrations/ice/diagnostic_profiles` for the sea ice submodel). The _detailed_ profiles request a large number of variables at higher frequencies, while the _standard_ profiles restrict the output to variables more regularly used across the community. Lists of the variables saved by each preset are available [here](https://forum.access-hive.org.au/t/preset-output-profiles-for-esm1-5/3629).
+Each submodel's _control_ directory contains _detailed_ and _standard_ presets for controlling the output, located in the `diagnostic_profiles` subdirectories (e.g. `~/access-esm/preindustrial+concentrations/ice/diagnostic_profiles` for the sea ice submodel). The _detailed_ profiles request a large number of variables at higher frequencies, while the _standard_ profiles restrict the output to variables more regularly used across the community. Details on the variables saved by each preset are available in [this Hive Forum topic](https://forum.access-hive.org.au/t/preset-output-profiles-for-esm1-5/3629).
 
 Selecting a preset output profile to use in a simulation can be done by pointing the following symbolic links to the desired profile:
 

--- a/docs/models/run-a-model/run-access-esm.md
+++ b/docs/models/run-a-model/run-access-esm.md
@@ -643,7 +643,7 @@ To modify these options please refer to the User Guide of the respective model c
 ### Controlling model output
 Selecting the variables to save from a simulation can be a balance between enabling future analysis and minimising storage requirements. The choice and frequency of variables saved by each model can be configured from within each submodel's _control_ directory. 
 
-Each submodel's _control_ directory contains _detailed_ and _standard_ presets for controlling the output, located in the `diagnostic_profiles` subdirectories (e.g. `~/access-esm/preindustrial+concentrations/ice/diagnostic_profiles` for the sea ice submodel). The _detailed_ profiles request a large number of variables at higher frequencies, while the _standard_ profiles restrict the output to variables more regularly used across the community.
+Each submodel's _control_ directory contains _detailed_ and _standard_ presets for controlling the output, located in the `diagnostic_profiles` subdirectories (e.g. `~/access-esm/preindustrial+concentrations/ice/diagnostic_profiles` for the sea ice submodel). The _detailed_ profiles request a large number of variables at higher frequencies, while the _standard_ profiles restrict the output to variables more regularly used across the community. Lists of the variables saved by each preset are available [here](https://forum.access-hive.org.au/t/preset-output-profiles-for-esm1-5/3629).
 
 Selecting a preset output profile to use in a simulation can be done by pointing the following symbolic links to the desired profile:
 


### PR DESCRIPTION
## Description

Fixes #775. This pull request adds a link to the tables of the variables saved by each ESM1.5 output preset to the [_Run ACCESS ESM1.5_ tutorial](https://access-hive.org.au/models/run-a-model/run-access-esm/)

## Type of change

- [x] New link / content

## Checklist:

- [x] The new content is accessible and located in the appropriate section
- [x] My changes do not break navigation and do not generate new warnings
- [x] I have checked that the links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings
- [ ] I have chosen the correct tag for the level of [support provided](https://access-hive.org.au/#support)

