### PR TITLE
Better placement for itro images

### DIFF
--- a/docs/about/contact.md
+++ b/docs/about/contact.md
@@ -1,6 +1,6 @@
 #  Contact 
 
-![Contact](/assets/contact-img.jpg){: class="intro-img img-cover with-border" loading="lazy"}
+![Contact](/assets/contact-img.jpg){: class="intro-img img-cover round-edges" loading="lazy"}
 
 ACCESS-Hive Docs is an initiative of the [Australian Earth-System Simulator (ACCESS-NRI)](https://www.access-nri.org.au/about/what-is-access-nri).
 

--- a/docs/about/contribute/index.md
+++ b/docs/about/contribute/index.md
@@ -1,6 +1,6 @@
 # Contribute to ACCESS-Hive Docs
 
-![Contribute image](/assets/github-how-to-contribute.jpg){: class="intro-img img-cover with-border" loading="lazy"}
+![Contribute image](/assets/github-how-to-contribute.jpg){: class="intro-img img-cover round-edges" loading="lazy"}
 
 ACCESS-Hive Docs is an open user portal which hosts the documentation relevant to the Australian Community Climate and Earth System Simulator (ACCESS) community.
 

--- a/docs/about/user_support/ask_on_forum.md
+++ b/docs/about/user_support/ask_on_forum.md
@@ -16,7 +16,7 @@ You can start a new discussion topic on the [Hive Forum] in just 3 simple steps:
 
 :material-tag:{: class="twemoji icon-before-text nri-light-blue-color"} [Tag the request with the label `help`](https://forum.access-hive.org.au/docs?topic=846)
 
-![Ask on forum](/assets/ask-on-forum-diagram.png){: class="white-background with-border example-img" loading="lazy"}
+![Ask on forum](/assets/ask-on-forum-diagram.png){: class="white-background round-edges example-img" loading="lazy"}
 
 ## Next steps...
 
@@ -32,4 +32,4 @@ After a discussion topic is posted on the forum, the ACCESS-NRI and community ex
 
 :fontawesome-regular-circle-check:{: class="twemoji icon-before-text nri-green-color"} Request is solved. 
 
-![ACCESS-NRI Support Model](/assets/access-nri-support.png){: class="white-background with-border example-img" loading="lazy"}
+![ACCESS-NRI Support Model](/assets/access-nri-support.png){: class="white-background round-edges example-img" loading="lazy"}

--- a/docs/about/user_support/index.md
+++ b/docs/about/user_support/index.md
@@ -14,7 +14,7 @@ Click on the questions to unfold the answers.
     !!! warning
         **ACCESS-Hive** (without any other term attached) is an "umbrella" term that includes both the Hive Docs and Hive Forum, but should not be used in place of any of the two, to avoid confusion.
     
-    <!-- ![Diagram showing how ACCESS-NRI and the Climate Research Working Groups engage with each other through the Hive Docs and the Hive Forum](/assets/access_hive_links.png){: class="with-border centered" style="width: 50%" loading="lazy"} -->
+    <!-- ![Diagram showing how ACCESS-NRI and the Climate Research Working Groups engage with each other through the Hive Docs and the Hive Forum](/assets/access_hive_links.png){: class="round-edges centered" style="width: 50%" loading="lazy"} -->
 
 ??? question "What is the difference between _model_, _model component_, and _model configuration_?"
     A **model component** (sometimes referred to simply as component) is a codebase that is typically compiled into a single executable. It usually runs independently and communicates with other components via a coupler.
@@ -35,7 +35,7 @@ Click on the questions to unfold the answers.
 
     Climate science - like all science - is based on the comparison of different models and hypothesis with observational data. We provide or support the frameworks to perform such comparisons as part of the **model evaluation**. The different model hypotheses, or more practically speaking *model experiments*, are created by executing different model configurations with different setups; for example by perturbing initial conditions or by adding new physical prescriptions to the models.
     
-    ![Diagram showing how running ACCESS model configurations with different setups create different experiments](/assets/how_does_it_work_together.png){: class="with-border centered" style="width: 75%" loading="lazy"}
+    ![Diagram showing how running ACCESS model configurations with different setups create different experiments](/assets/how_does_it_work_together.png){: class="round-edges centered" style="width: 75%" loading="lazy"}
 
 ??? question "What is a control experiment? Why are they important?"
     A **control experiment** (sometimes also called a "control run") is an experiment that is designed to be used as a comparison against which perturbation experiments can be compared.

--- a/docs/css/access-nri.css
+++ b/docs/css/access-nri.css
@@ -1179,8 +1179,9 @@ img.terminalSwitch:hover {
 
 img.intro-img {
   max-height: 12rem;
-  display: block;
-  margin: 0 auto;
+  max-width: 40%;
+  margin: 0 0 0.5rem 1rem;
+  float: right;
 }
 
 /* Aspect ratios */

--- a/docs/css/access-nri.css
+++ b/docs/css/access-nri.css
@@ -1211,10 +1211,8 @@ img.intro-img {
 }
 
 /* With borders */
-.with-border {
+.round-edges {
   border-radius: 0.6rem;
-  border: var(--border-width) solid var(--card-borders);
-  box-sizing: border-box;
 }
 
 /* Add padding to image container */

--- a/docs/models/configurations/access-cm.md
+++ b/docs/models/configurations/access-cm.md
@@ -1,6 +1,6 @@
 # ACCESS-CM
 
-![ACCESS CM model](/assets/model-config-logos/configurations-without-titles/access-cm.png){: class="img-contain white-background with-border with-padding intro-img" loading="lazy"}
+![ACCESS CM model](/assets/model-config-logos/configurations-without-titles/access-cm.png){: class="img-contain white-background round-edges with-padding intro-img" loading="lazy"}
 
 The ACCESS Coupled Model (ACCESS-CM) is a fully-coupled global climate model that includes [atmosphere](/models/model_components/atmosphere), [aerosols and atmospheric chemistry](/models/model_components/aerosols_atmospheric_chemistry), [land](/models/model_components/land), [ocean](/models/model_components/ocean) and [sea ice](/models/model_components/sea-ice) components, linked together by a [coupler](/models/model_components/coupler).<br>
 It produces physical climate simulations.

--- a/docs/models/configurations/access-esm.md
+++ b/docs/models/configurations/access-esm.md
@@ -1,6 +1,6 @@
 # ACCESS-ESM
 
-![ACCESS ESM model](/assets/model-config-logos/configurations-without-titles/access-esm.png){: class="img-contain white-background with-border with-padding intro-img" loading="lazy"}
+![ACCESS ESM model](/assets/model-config-logos/configurations-without-titles/access-esm.png){: class="img-contain white-background round-edges with-padding intro-img" loading="lazy"}
 
 The ACCESS Earth System Model (ACCESS-ESM) is a fully-coupled global climate model that includes [atmosphere](/models/model_components/atmosphere), [land](/models/model_components/land), [ocean](/models/model_components/ocean), [sea ice](/models/model_components/sea-ice), [ocean biogeochemistry](/models/model_components/bgc_ocean) and [land biogeochemistry](/models/model_components/bgc_land) components, linked together by a [coupler](/models/model_components/coupler).<br>
 This means it can simulate both the physical climate and global biogeochemical cycles, in particular the carbon cycle.

--- a/docs/models/configurations/access-om.md
+++ b/docs/models/configurations/access-om.md
@@ -1,7 +1,7 @@
 
 # ACCESS-OM
 
-![ACCESS OM model](/assets/model-config-logos/configurations-without-titles/access-om.png){: class="img-contain white-background with-border with-padding intro-img" loading="lazy"}
+![ACCESS OM model](/assets/model-config-logos/configurations-without-titles/access-om.png){: class="img-contain white-background round-edges with-padding intro-img" loading="lazy"}
 
 The ACCESS Ocean Model (ACCESS-OM) is a global coupled ocean model that includes [ocean](/models/model_components/ocean), [ocean biogeochemistry](/models/model_components/bgc_ocean), and [sea ice](/models/model_components/sea-ice) components, linked together by a [coupler](/models/model_components/coupler).<br>
 The atmospheric fields that drive the model are provided by a data source, usually derived from reanalysis.

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -1,6 +1,6 @@
 # Supported ACCESS Models
 
-![Overview of models](/assets/models_flow_diagram.png){: class="intro-img with-border" }
+![Overview of models](/assets/models_flow_diagram.png){: class="intro-img round-edges" }
 
 ACCESS models are computer codes comprising complex mathematical representations of major Earth system components (atmosphere, land surface, ocean and sea ice) based on physical, biological and chemical principles or laws. Different ACCESS model components can be linked together via a coupler to form ACCESS model configurations (e.g. ACCESS-ESM), which are then used to simulate realistic past or future conditions and idealised experiments.
 

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -1,8 +1,8 @@
 # Supported ACCESS Models
 
-ACCESS models are computer codes comprising complex mathematical representations of major Earth system components (atmosphere, land surface, ocean and sea ice) based on physical, biological and chemical principles or laws. Different ACCESS model components can be linked together via a coupler to form ACCESS model configurations (e.g. ACCESS-ESM), which are then used to simulate realistic past or future conditions and idealised experiments.
-
 ![Overview of models](/assets/models_flow_diagram.png){: class="intro-img with-border" }
+
+ACCESS models are computer codes comprising complex mathematical representations of major Earth system components (atmosphere, land surface, ocean and sea ice) based on physical, biological and chemical principles or laws. Different ACCESS model components can be linked together via a coupler to form ACCESS model configurations (e.g. ACCESS-ESM), which are then used to simulate realistic past or future conditions and idealised experiments.
 
 ## Supported ACCESS Model Configurations
 <div class="card-container">

--- a/docs/models/model_components/aerosols_atmospheric_chemistry.md
+++ b/docs/models/model_components/aerosols_atmospheric_chemistry.md
@@ -1,6 +1,6 @@
 #  Aerosol and Atmospheric Chemistry components 
 
-![Aerosol and Atmospheric Chemistry components image](/assets/component-logos/component-maps/aerosol-chemistry-component-map.png){: class="img-contain white-background with-border with-padding intro-img" loading="lazy"}
+![Aerosol and Atmospheric Chemistry components image](/assets/component-logos/component-maps/aerosol-chemistry-component-map.png){: class="img-contain white-background round-edges with-padding intro-img" loading="lazy"}
 
 ## UKCA
 

--- a/docs/models/model_components/atmosphere.md
+++ b/docs/models/model_components/atmosphere.md
@@ -1,6 +1,6 @@
 #  Atmosphere component
 
-![Atmosphere component image](/assets/component-logos/component-maps/atmosphere-component-map.png){: class="img-contain white-background with-border with-padding intro-img" loading="lazy"}
+![Atmosphere component image](/assets/component-logos/component-maps/atmosphere-component-map.png){: class="img-contain white-background round-edges with-padding intro-img" loading="lazy"}
 
 ## Unified Model (UM)
 

--- a/docs/models/model_components/bgc_land.md
+++ b/docs/models/model_components/bgc_land.md
@@ -1,7 +1,7 @@
 
 #  Biogeochemistry Land component
 
-![Biogeochemistry Land component image](/assets/component-logos/component-maps/bgc-land-component-map.png){: class="img-contain white-background with-border with-padding intro-img" loading="lazy"}
+![Biogeochemistry Land component image](/assets/component-logos/component-maps/bgc-land-component-map.png){: class="img-contain white-background round-edges with-padding intro-img" loading="lazy"}
 
 ## CASA-CNP
 

--- a/docs/models/model_components/bgc_ocean.md
+++ b/docs/models/model_components/bgc_ocean.md
@@ -1,6 +1,6 @@
 #  Biogeochemistry Ocean component
 
-![BGC Ocean component image](/assets/component-logos/component-maps/bgc-ocean-component-map.png){: class="img-contain white-background with-border with-padding intro-img" loading="lazy"}
+![BGC Ocean component image](/assets/component-logos/component-maps/bgc-ocean-component-map.png){: class="img-contain white-background round-edges with-padding intro-img" loading="lazy"}
 
 ## WOMBAT
 

--- a/docs/models/model_components/coupler.md
+++ b/docs/models/model_components/coupler.md
@@ -1,6 +1,6 @@
 # Coupler
 
-![Coupler component image](/assets/component-logos/component-maps/coupler-component-map.png){: class="img-contain white-background with-border with-padding intro-img" loading="lazy"}
+![Coupler component image](/assets/component-logos/component-maps/coupler-component-map.png){: class="img-contain white-background round-edges with-padding intro-img" loading="lazy"}
 
 A coupler is a software package that allows synchronised exchanges of coupling information between numerical models representing different components of the climate system.
 

--- a/docs/models/model_components/land.md
+++ b/docs/models/model_components/land.md
@@ -1,6 +1,6 @@
 #  Land Surface component
 
-![Land Surface component image](/assets/component-logos/component-maps/land-component-map.png){: class="img-contain white-background with-border with-padding intro-img" loading="lazy"}
+![Land Surface component image](/assets/component-logos/component-maps/land-component-map.png){: class="img-contain white-background round-edges with-padding intro-img" loading="lazy"}
 
 ## CABLE
 

--- a/docs/models/model_components/ocean.md
+++ b/docs/models/model_components/ocean.md
@@ -1,6 +1,6 @@
 #  Ocean component 
 
-![Ocean component image](/assets/component-logos/component-maps/ocean-component-map.png){: class="img-contain white-background with-border with-padding intro-img" loading="lazy"}
+![Ocean component image](/assets/component-logos/component-maps/ocean-component-map.png){: class="img-contain white-background round-edges with-padding intro-img" loading="lazy"}
 
 ## Modular Ocean Model (MOM)
 The [Modular Ocean Model (MOM)](https://mom-ocean.github.io) is one of the ocean components of the ACCESS climate model systems. Used to simulate ocean currents at both regional and global scales, MOM is an invaluable tool for studying the global ocean climate system, as well as having capabilities for regional and coastal applications. 

--- a/docs/models/model_components/sea-ice.md
+++ b/docs/models/model_components/sea-ice.md
@@ -1,6 +1,6 @@
 #  Sea Ice component 
 
-![Sea Ice component image](/assets/component-logos/component-maps/sea-ice-component-map.png){: class="img-contain white-background with-border with-padding intro-img" loading="lazy"}
+![Sea Ice component image](/assets/component-logos/component-maps/sea-ice-component-map.png){: class="img-contain white-background round-edges with-padding intro-img" loading="lazy"}
 
 ## CICE
 CICE is a numerical model for simulating the growth, melting and movement of polar sea ice. This software package was developed by researchers at [Los Alamos National Laboratory team](https://www.lanl.gov) and is currently managed by the [CICE Consortium](https://github.com/CICE-Consortium/About-Us/wiki), an international group of institutions formed to maintain and develop CICE in the public domain.

--- a/drafts/configurations/access-am.md
+++ b/drafts/configurations/access-am.md
@@ -1,7 +1,7 @@
 #  ACCESS-AM  
 
 
-<img src="../../../assets/model-config-logos/configurations-without-titles/access-am.png" alt="ACCESS AM model" class="white-background with-border with-padding"></img>
+<img src="../../../assets/model-config-logos/configurations-without-titles/access-am.png" alt="ACCESS AM model" class="white-background round-edges with-padding"></img>
 
 The ACCESS Atmosphere Model (ACCESS-AM) is a global model with atmosphere and land surface components. It is often used in Atmospheric Model Intercomparison Project (AMIP) experiments where it is driven by historically observed sea surface temperature and sea ice data.
 


### PR DESCRIPTION
Fixes #720.

- [x] Made intro images (images with the 'intro-img' class) float to the right and have better margins and max dimensions.
- [x] Fixed placement of intro image in models page.