### PR TITLE
getting_started/spack.md: use --fresh even for the first concretize

### DIFF
--- a/docs/getting_started/spack.md
+++ b/docs/getting_started/spack.md
@@ -59,7 +59,7 @@ git clone https://github.com/ACCESS-NRI/ACCESS-TEST.git
 spack env create test ACCESS-TEST/spack.yaml
 spack env activate -p test
 spack find
-spack concretize -f
+spack concretize -f --fresh
 spack install --verbose
 spack find
 spack uninstall --remove --all


### PR DESCRIPTION
To be on the safe side, we are going to recommend using `--fresh` even for the first call of `concretize`. See https://github.com/ACCESS-NRI/ACCESS-OM2/issues/81