### PR TITLE
Remove slack from footer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -195,9 +195,6 @@ extra:
     - icon: fontawesome/brands/linkedin
       link: https://www.linkedin.com/in/access-nri
       name: ACCESS-NRI on Linkedin
-    # - icon: fontawesome/brands/slack
-    #   link: https://access-nri.slack.com/
-    #   name: Join ACCESS-NRI Slack Channel
   analytics:
     provider: google
     property: G-2T6SQEH2CX

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -195,9 +195,9 @@ extra:
     - icon: fontawesome/brands/linkedin
       link: https://www.linkedin.com/in/access-nri
       name: ACCESS-NRI on Linkedin
-    - icon: fontawesome/brands/slack
-      link: https://access-nri.slack.com/
-      name: Join ACCESS-NRI Slack Channel
+    # - icon: fontawesome/brands/slack
+    #   link: https://access-nri.slack.com/
+    #   name: Join ACCESS-NRI Slack Channel
   analytics:
     provider: google
     property: G-2T6SQEH2CX


### PR DESCRIPTION
## Description

Remove slack from footer as slack is for internal communications only

Fixes #781

## Checklist:

- [ ] My changes do not break navigation and do not generate new warnings

