### PR TITLE
Fix spack develop title and texts

### DIFF
--- a/docs/getting_started/spack.md
+++ b/docs/getting_started/spack.md
@@ -47,7 +47,7 @@ ln -s -r -v spack-config/v0.22/gadi/* spack/etc/spack/
 !!! success
     Your _Spack_ setup is complete!
 
-For instructions on how to build an ACCESS model using _Spack_, refer to [Build an ACCESS model](/models/run-a-model/build_a_model).
+For instructions on how to build an ACCESS model using _Spack_, refer to [Modify an ACCESS model's source code](/models/run-a-model/build_a_model).
 
 ## Enable Spack
 

--- a/docs/models/run-a-model/build_a_model.md
+++ b/docs/models/run-a-model/build_a_model.md
@@ -314,7 +314,7 @@ If the new source code for the development package already exists in the filesys
 
 For example, to mark `mom5` as a development package using the `development_version` tag and with the new source code in the `/path/to/mom5/new/source/code` folder, we can run:
 ```
-spack develop mom5@development_version --path /path/to/mom5/new/source/code
+spack develop --path /path/to/mom5/new/source/code mom5@development_version
 ```
 !!! tip
     This command should not display any output

--- a/docs/models/run-a-model/build_a_model.md
+++ b/docs/models/run-a-model/build_a_model.md
@@ -6,15 +6,14 @@
 {% set spack_setup = "/getting_started/spack" %}
 [gadi]: https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi#id-0.WelcometoGadi-Overview
 
-# Build an ACCESS model
+# Modify an ACCESS model's source code
 
 ## About
 
-The instructions below outline how to build an ACCESS model using the build-from-source package manager [Spack](https://spack.readthedocs.io).<br>
+The instructions below outline how to build an ACCESS model and its dependencies, using the build-from-source package manager [Spack](https://spack.readthedocs.io).<br>
 This build workflow is specifically designed to run on the [National Computating Infrastructure (NCI)](https://nci.org.au/about-us/who-we-are) supercomputer [_Gadi_][gadi].
 
-
-As an example, in the following instructions we will show how to build a modified [mom5 component](/models/model_components/ocean/#mom5) for [ACCESS-ESM1.5](/models/configurations/access-esm/#access-esm15). All other components and packages (i.e., dependencies) will remain the same as the official [ACCESS-ESM1.5 release]({{esm1_5_build_config}}).
+As an example, in the following instructions we will show how to modify [mom5 component](/models/model_components/ocean/#mom5) for [ACCESS-ESM1.5](/models/configurations/access-esm/#access-esm15) and re-compile the relevant ACCESS-ESM1.5 dependencies. All the other components and packages (i.e., dependencies) will remain the same as the official [ACCESS-ESM1.5 release]({{esm1_5_build_config}}).
 
 !!! tip
     The instructions below remain valid (with simple tweaks) for any model or package.

--- a/docs/models/run-a-model/index.md
+++ b/docs/models/run-a-model/index.md
@@ -30,10 +30,10 @@ If you are unsure which ACCESS model is the right choice for your experiment, ta
     </a>
     <a href="/models/run-a-model/build_a_model" class="vertical-card aspect-ratio1to1">
         <div class="card-image-container">
-            <img class="img-contain with-padding white-background" src="/assets/model-config-logos/globe_visualisation/access_om_globe_visualisation.png" alt="Build a model">
+            <img class="img-contain with-padding white-background" src="/assets/model-config-logos/globe_visualisation/access_om_globe_visualisation.png" alt="Modify a model's source code">
         </div>
         <div class="card-text-container bold">   
-            Build an ACCESS model
+            Modify an ACCESS model's source code
         </div>
     </a>
 </div>

--- a/docs/models/run-a-model/run-access-esm.md
+++ b/docs/models/run-a-model/run-access-esm.md
@@ -642,7 +642,7 @@ To modify these options please refer to the User Guide of the respective model c
 
 ### Create a custom {{ model }} build
 All the executables needed to run {{ model }} are pre-built into independent configurations using _Spack_.<br>
-To customise {{ model }}'s build (for example to run {{ model }} with changes in the source code of one of its component), refer to [Build {{ model }}](/models/run-a-model/build_a_model#{{model|lower}}).
+To customise {{ model }}'s build (for example to run {{ model }} with changes in the source code of one of its component), refer to [Modify an ACCESS model's source code](/models/run-a-model/build_a_model#{{model|lower}}).
 
 ### Controlling model output
 Selecting the variables to save from a simulation can be a balance between enabling future analysis and minimising storage requirements. The choice and frequency of variables saved by each model can be configured from within each submodel's _control_ directory. 

--- a/docs/models/run-a-model/run-access-om.md
+++ b/docs/models/run-a-model/run-access-om.md
@@ -565,7 +565,7 @@ To modify these options please refer to the User Guide of the respective model c
 
 ### Create a custom {{ model }} build
 All the executables needed to run {{ model }} are pre-built into independent configurations using _Spack_.<br>
-To customise {{ model }}'s build (for example to run {{ model }} with changes in the source code of one of its component), refer to [Build {{ model }}](/models/run-a-model/build_a_model#{{model|lower}}).
+To customise {{ model }}'s build (for example to run {{ model }} with changes in the source code of one of its component), refer to [Modify an ACCESS model's source code](/models/run-a-model/build_a_model#{{model|lower}}).
 
 ## Get Help
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,7 +123,7 @@ nav:
     - Run ACCESS-CM: models/run-a-model/run-access-cm.md
     - Run ACCESS-ESM: models/run-a-model/run-access-esm.md
     - Run ACCESS-OM: models/run-a-model/run-access-om.md
-    - Build an ACCESS Model: models/run-a-model/build_a_model.md
+    - Modify an ACCESS model's source code: models/run-a-model/build_a_model.md
 
   - Data and Model Evaluation:
     - model_evaluation/index.md


### PR DESCRIPTION
- [x] Fixed '--path' option order to 'spack develop' command. Fixes #832.
- [x] Changed 'Build an ACCESS model' to 'Modify an ACCESS model's source code' + minor adjustments to the texts. Fixes #828.
