### PR TITLE
getting_started/spack.md: move the warning above the title

### DIFF
--- a/docs/getting_started/spack.md
+++ b/docs/getting_started/spack.md
@@ -1,8 +1,8 @@
-# Set up Spack for building ACCESS models
-
 !!! danger
     This page is tailored to experienced users and collaborators developing ACCESS models.<br>
     This step is *not* required if you *only* want to run a model. If you are looking for information on how to run a model, refer to the [Run a Model](/models/run-a-model) section.
+
+# Set up Spack for building ACCESS models
 
 [Spack](https://spack.io/about/) is a build-from-source package manager, specifically designed to simplify the installation of scientific software on supercomputers.
 


### PR DESCRIPTION
Move the warning above the title to be consistent with "Modify an ACCESS model's source code".