### PR TITLE
Updated spack example output

### DIFF
--- a/docs/getting_started/spack.md
+++ b/docs/getting_started/spack.md
@@ -107,191 +107,81 @@ spack concretize -f --fresh
 spack install
 ```
 
+!!! warning
+    Some of the commands above might take several minutes to complete.
+
 <terminal-window lineDelay=0>
+    <!-- spack find -->
     <terminal-line directory="[test]" class="spack" data="input" lineDelay=600>spack find</terminal-line>
     <terminal-line lineDelay=500><span class="spack-indigo">\==></span> In environment test</terminal-line>
     <terminal-line><span class="spack-indigo">\==></span> 1 root specs</terminal-line>
-    <terminal-line><span class="spack-grey keep-blanks"> - </span> access-test<span class="spack-cyan">@git.2024.09.20</span></terminal-line>
+    <terminal-line><span class="spack-grey keep-blanks"> - </span> access-test<span class="spack-cyan">@git.2025.04.000=2025.04.000</span></terminal-line>
     <terminal-line></terminal-line>
     <terminal-line><span class="spack-indigo">\==></span> 0 installed packages</terminal-line>
+    <!-- spack concretize -->
     <terminal-line lineDelay=600 directory="[test]" class="spack" data="input">spack concretize -f --fresh</terminal-line>
-    <terminal-line lineDelay=2000><span class="spack-indigo">\==></span> Concretized access-test<span class="spack-cyan">@git.2024.09.20</span></terminal-line>
+    <terminal-line lineDelay=2000><span class="spack-indigo">\==></span> Concretized access-test@git.2025.04.000=2025.04.000</terminal-line>
     <terminal-line>
-        <span class="spack-grey keep-blanks"> -   hmy75yl</span> access-test<span class="spack-cyan">@git.2024.09.20</span><span class="spack-green">%intel@2021.10.0</span><span class="spack-indigo">\~deterministic build_system=bundle</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
+        <span class="spack-grey keep-blanks"> -   ih4cowp</span> access-test<span class="spack-cyan">@git.2025.04.000=2025.04.000</span><span class="spack-green">%intel@2021.10.0</span><span class="spack-indigo">+mpi build_system=bundle</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
     </terminal-line>
     <terminal-line>
-        <span class="spack-green">[e]</span> <span class="spack-grey keep-blanks"> 5elnsoi    </span> ^glibc<span class="spack-cyan">@2.28</span><span class="spack-green">%intel@2021.10.0</span> <span class="spack-indigo">build_system=autotools</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
+        <span class="spack-grey keep-blanks"> -   bcixn5z    </span> <span>^access-test-component<span class="spack-cyan">@main</span><span class="spack-green">%intel@2021.10.0</span><span class="spack-indigo">\~ipo+mpi build_system=cmake build_type=Release generator=make</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
     </terminal-line>
     <terminal-line>
-        <span class="spack-grey keep-blanks"> -   kok5n7h    </span> ^oasis3-mct<span class="spack-cyan">@git.2023.11.09=2023.11.09</span><span class="spack-green">%intel@2021.10.0</span><span class="spack-indigo">\~deterministic\~optimisation_report build_system=makefile</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
+        <span class="spack-grey keep-blanks"> -   rldyvqn        </span> <span>^cmake<span class="spack-cyan">@3.24.2</span><span class="spack-green">%intel@2021.10.0</span><span class="spack-indigo">\~doc+ncurses+ownlibs build_system=generic build_type=Release</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
     </terminal-line>
     <terminal-line>
-        <span class="spack-grey keep-blanks"> -   doeoclg        </span> ^gmake<span class="spack-cyan">@4.4.1</span><span class="spack-green">%intel@2021.10.0</span><span class="spack-indigo">\~guile build_system=generic</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
+        <span class="spack-grey keep-blanks"> -   doeoclg        </span> <span>^gmake<span class="spack-cyan">@4.4.1</span><span class="spack-green">%intel@2021.10.0</span><span class="spack-indigo">\~guile build_system=generic</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
     </terminal-line>
     <terminal-line>
-         <span class="spack-grey keep-blanks"> -   ntfunrm        </span> ^netcdf-fortran<span class="spack-cyan">@4.6.1</span><span class="spack-green">%intel@2021.10.0</span><span class="spack-indigo">\~doc+pic+shared build_system=autotools</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
+        <span class="spack-grey keep-blanks"> -   qg5spmh        </span> <span>^openmpi<span class="spack-cyan">@4.1.5</span><span class="spack-green">%intel@2021.10.0</span><span class="spack-indigo">\~atomics\~cuda\~cxx\~cxx_exceptions\~gpfs\~internal-hwloc\~internal-libevent\~internal-pmix\~java\~legacylaunchers\~lustre\~memchecker\~openshmem\~orterunprefix\~romio+rsh\~singularity\~static+vt+wrapper-rpath build_system=autotools fabrics=none romio-filesystem=none schedulers=none</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
     </terminal-line>
     <terminal-line>
-        <span class="spack-grey keep-blanks"> -   vob7om3            </span> ^netcdf-c<span class="spack-cyan">@4.9.2</span><span class="spack-green">%intel@2021.10.0</span><span class="spack-indigo">+blosc\~byterange\~dap\~fsync\~hdf4\~jna+mpi\~nczarr_zip+optimize\~parallel-netcdf+pic+shared+szip+zstd build_system=autotools patches=0161eb8</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
+        <span class="spack-grey keep-blanks"> -   5elnsoi    </span> <span>^glibc<span class="spack-cyan">@2.28</span><span class="spack-green">%intel@2021.10.0</span> <span class="spack-indigo">build_system=autotools</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
     </terminal-line>
+    <terminal-line></terminal-line>
     <terminal-line>
-        <span class="spack-grey keep-blanks"> -   357vng5                </span> ^bzip2<span class="spack-cyan">@1.0.8</span><span class="spack-green">%intel@2021.10.0</span><span class="spack-indigo">\~debug\~pic+shared build_system=generic</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
+        <span class="spack-indigo">\==></span> Updating view at /g/data/$PROJECT/$USER/spack/0.22/environments/test/.spack-env/view</terminal-line>
     </terminal-line>
-    <terminal-line>
-        <span class="spack-grey keep-blanks"> -   y7n7vkn                    </span> ^diffutils<span class="spack-cyan">@3.10</span><span class="spack-green">%intel@2021.10.0</span> <span class="spack-indigo">build_system=autotools</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-grey keep-blanks"> -   55ipnye                        </span> ^libiconv<span class="spack-cyan">@1.17</span><span class="spack-green">%intel@2021.10.0</span> <span class="spack-indigo">build_system=autotools libs=shared,static</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-grey keep-blanks"> -   zrjfo56                </span> ^c-blosc<span class="spack-cyan">@1.21.5</span><span class="spack-green">%intel@2021.10.0</span><span class="spack-indigo">+avx2\~ipo build_system=cmake build_type=Release generator=make</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-green">[e]</span> <span class="spack-grey keep-blanks"> rldyvqn                    </span> ^cmake<span class="spack-cyan">@3.24.2</span><span class="spack-green">%intel@2021.10.0</span><span class="spack-indigo">\~doc+ncurses+ownlibs build_system=generic build_type=Release</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
-</terminal-line>
-    <terminal-line>
-        <span class="spack-grey keep-blanks"> -   7a5olrr                    </span> ^lz4<span class="spack-cyan">@1.9.4</span><span class="spack-green">%intel@2021.10.0</span><span class="spack-indigo">+pic build_system=makefile libs=shared,static</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-grey keep-blanks"> -   wk4pvru                    </span> ^snappy<span class="spack-cyan">@1.1.10</span><span class="spack-green">%intel@2021.10.0</span><span class="spack-indigo">\~ipo+pic+shared build_system=cmake build_type=Release generator=make</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-grey keep-blanks"> -   aumsrgz                </span> ^hdf5<span class="spack-cyan">@1.14.3</span><span class="spack-green">%intel@2021.10.0</span><span class="spack-indigo">\~cxx\~fortran+hl\~ipo\~java\~map+mpi+shared\~subfiling\~szip\~threadsafe+tools api=default build_system=cmake build_type=Release generator=make patches=82088c8</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
-    </terminal-line>
-    <terminal-line>
-         <span class="spack-grey keep-blanks"> -   vrupasu                    </span> ^pkgconf<span class="spack-cyan">@2.2.0</span><span class="spack-green">%intel@2021.10.0</span> <span class="spack-indigo">build_system=autotools</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-grey keep-blanks"> -   x4hw5jq                </span> ^libaec<span class="spack-cyan">@1.0.6</span><span class="spack-green">%intel@2021.10.0</span><span class="spack-indigo">\~ipo+shared build_system=cmake build_type=Release generator=make</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-grey keep-blanks"> -   wa2x7rh                </span> ^zlib-ng<span class="spack-cyan">@2.1.6</span><span class="spack-green">%intel@2021.10.0</span><span class="spack-indigo">+compat+new_strategies+opt+pic+shared build_system=autotools</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-grey keep-blanks"> -   kzc7pcv                </span> ^zstd<span class="spack-cyan">@1.5.6</span><span class="spack-green">%intel@2021.10.0</span><span class="spack-indigo">\~programs build_system=makefile libs=shared,static</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-green">[e]</span> <span class="spack-grey keep-blanks"> uvea7q2        </span> ^openmpi<span class="spack-cyan">@4.1.5</span><span class="spack-green">%intel@2021.10.0</span> <span class="spack-indigo">cppflags='-diag-disable=10441' \~atomics\~cuda\~cxx\~cxx_exceptions\~gpfs\~internal-hwloc\~internal-libevent\~internal-pmix\~java\~legacylaunchers\~lustre\~memchecker\~openshmem\~orterunprefix\~romio+rsh\~singularity\~static+vt+wrapper-rpath build_system=autotools fabrics=none romio-filesystem=none schedulers=none</span> <span class="spack-pink">arch=linux-rocky8-x86_64</span>
-    </terminal-line>
+    <!-- spack install -->
     <terminal-line directory="[test]" class="spack" lineDelay=2000 data="input">
         spack install
     </terminal-line>
     <terminal-line>
-        <span class="spack-indigo bold">\==></span> <span class="spack-highlighted">Installing</span> <span class="spack-green">glibc-2.28-mqjolvbeskcnhz5chvtdshk4x4sfnycs</span> <span class="spack-highlighted">[1/19]</span>
+        <span class="spack-indigo bold">\==></span> <span class="spack-highlighted">Installing</span> <span class="spack-green">glibc-2.28-5elnsoiqgcg5k5zmmwsp33bmnmaa3g5p</span> <span class="spack-highlighted">[1/6]</span>
     </terminal-line>
     <terminal-line>
-        <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/glibc-2.28-mqjolvbeskcnhz5chvtdshk4x4sfnycs
+        <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/glibc-2.28-5elnsoiqgcg5k5zmmwsp33bmnmaa3g5p
     </terminal-line>
     <terminal-line>
-        <span class="spack-indigo bold">\==></span> <span class="spack-highlighted">Installing</span> <span class="spack-green">cmake-3.24.2-vc4y4c64s55j5u6kp37ciw2hcghuxhhc</span> <span class="spack-highlighted">[2/19]</span>
+        <span class="spack-indigo bold">\==></span> <span class="spack-highlighted">Installing</span> <span class="spack-green">cmake-3.24.2-vc4y4c64s55j5u6kp37ciw2hcghuxhhc</span> <span class="spack-highlighted">[2/6]</span>
     </terminal-line>
     <terminal-line>
         <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/cmake-3.24.2-vc4y4c64s55j5u6kp37ciw2hcghuxhhc
     </terminal-line>
     <terminal-line>
-        <span class="spack-indigo bold">\==></span> <span class="spack-highlighted">Installing</span> <span class="spack-green">openmpi-4.0.2-ikhujrkyukytbkxxyk3mub44v63vuzfz</span> <span class="spack-highlighted">[3/19]</span>
+        <span class="spack-indigo bold">\==></span> <span class="spack-highlighted">Installing</span> <span class="spack-green">openmpi-4.1.5-qg5spmhetxnuvtyi7nuobd3nv7zwnu5f</span> <span class="spack-highlighted">[3/6]</span>
     </terminal-line>
     <terminal-line>
-        <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/openmpi-4.0.2-ikhujrkyukytbkxxyk3mub44v63vuzfz
+        <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/openmpi-4.1.5-qg5spmhetxnuvtyi7nuobd3nv7zwnu5f
     </terminal-line>
     <terminal-line>
-        <span class="spack-indigo bold">\==></span> <span   class="spack-highlighted">Installing</span> <span class="spack-green">gmake-4.4.1-j6yscmmcn3qws7n35klote7rivw7foa6</span> <span class="spack-highlighted">[4/19]</span>
+        <span class="spack-indigo bold">\==></span> <span   class="spack-highlighted">Installing</span> <span class="spack-green">gmake-4.4.1-j6yscmmcn3qws7n35klote7rivw7foa6</span> <span class="spack-highlighted">[4/6]</span>
     </terminal-line>
     <terminal-line>
         <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/gmake-4.4.1-j6yscmmcn3qws7n35klote7rivw7foa6
     </terminal-line>
     <terminal-line>
-        <span class="spack-indigo bold">\==></span> <span   class="spack-highlighted">Installing</span> <span class="spack-green">libaec-1.0.6-x4hw5jqq3zvnrgjicgweicomeaelulqq</span> <span class="spack-highlighted">[5/19]</span>
+        <span class="spack-indigo bold">\==></span> <span   class="spack-highlighted">Installing</span> <span class="spack-green">access-test-component-main-bcixn5z6ou7vlnogzgyy5z23jb4qeunx</span> <span class="spack-highlighted">[5/6]</span>
     </terminal-line>
     <terminal-line>
-        <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/libaec-1.0.6-x4hw5jqq3zvnrgjicgweicomeaelulqq
+        <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/access-test-component-main-bcixn5z6ou7vlnogzgyy5z23jb4qeunx
     </terminal-line>
     <terminal-line>
-        <span class="spack-indigo bold">\==></span> <span   class="spack-highlighted">Installing</span> <span class="spack-green">zlib-ng-2.1.6-wa2x7rho3km6qpiki56dpjlpsce4c5n6</span> <span class="spack-highlighted">[6/19]</span>
+        <span class="spack-indigo bold">\==></span> <span   class="spack-highlighted">Installing</span> <span class="spack-green">access-test-git.2025.04.000_2025.04.000-ih4cowpiz2kv6tnz4rkualxuly54tizr</span> <span class="spack-highlighted">[6/6]</span>
     </terminal-line>
     <terminal-line>
-        <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/zlib-ng-2.1.6-wa2x7rho3km6qpiki56dpjlpsce4c5n6
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-indigo bold">\==></span> <span   class="spack-highlighted">Installing</span> <span class="spack-green">snappy-1.1.10-wk4pvrufyvy7v3hxn5nwa3i3fncp3azm</span> <span class="spack-highlighted">[7/19]</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/snappy-1.1.10-wk4pvrufyvy7v3hxn5nwa3i3fncp3azm
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-indigo bold">\==></span> <span   class="spack-highlighted">Installing</span> <span class="spack-green">pkgconf-2.2.0-vrupasu7smpgcbarzpdwap45fcvjbjoa</span> <span class="spack-highlighted">[8/19]</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/pkgconf-2.2.0-vrupasu7smpgcbarzpdwap45fcvjbjoa
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-indigo bold">\==></span> <span   class="spack-highlighted">Installing</span> <span class="spack-green">zstd-1.5.6-kzc7pcve7csxlonb2uaxzgyyuqfx6cz4</span> <span class="spack-highlighted">[9/19]</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/zstd-1.5.6-kzc7pcve7csxlonb2uaxzgyyuqfx6cz4
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-indigo bold">\==></span> <span   class="spack-highlighted">Installing</span> <span class="spack-green">lz4-1.9.4-7a5olrrnewy7kmlh5x4bstziuheiqkz4</span> <span class="spack-highlighted">[10/19]</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/lz4-1.9.4-7a5olrrnewy7kmlh5x4bstziuheiqkz4
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-indigo bold">\==></span> <span   class="spack-highlighted">Installing</span> <span class="spack-green">libiconv-1.17-55ipnyeeqcpbfgaqfanu36viaqqni3sx</span> <span class="spack-highlighted">[11/19]</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/libiconv-1.17-55ipnyeeqcpbfgaqfanu36viaqqni3sx
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-indigo bold">\==></span> <span   class="spack-highlighted">Installing</span> <span class="spack-green">hdf5-1.14.3-aumsrgzvbh6grtyyegzuufilnqa7ftm7</span> <span class="spack-highlighted">[12/19]</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/hdf5-1.14.3-aumsrgzvbh6grtyyegzuufilnqa7ftm7
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-indigo bold">\==></span> <span   class="spack-highlighted">Installing</span> <span class="spack-green">c-blosc-1.21.5-zrjfo567d2n6ctwayae77z3b54mf23yc</span> <span class="spack-highlighted">[13/19]</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/c-blosc-1.21.5-zrjfo567d2n6ctwayae77z3b54mf23yc
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-indigo bold">\==></span> <span   class="spack-highlighted">Installing</span> <span class="spack-green">diffutils-3.10-y7n7vkngczu47neysm3retisvlsmw53l</span> <span class="spack-highlighted">[14/19]</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/diffutils-3.10-y7n7vkngczu47neysm3retisvlsmw53l
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-indigo bold">\==></span> <span   class="spack-highlighted">Installing</span> <span class="spack-green">bzip2-1.0.8-357vng5dpd7w7s7lletycxccjbl45ngt</span> <span class="spack-highlighted">[15/19]</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/bzip2-1.0.8-357vng5dpd7w7s7lletycxccjbl45ngt
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-indigo bold">\==></span> <span   class="spack-highlighted">Installing</span> <span class="spack-green">netcdf-c-4.9.2-vob7om32jopqwss5jilrdtqqogjvcmzb</span> <span class="spack-highlighted">[16/19]</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/netcdf-c-4.9.2-vob7om32jopqwss5jilrdtqqogjvcmzb
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-indigo bold">\==></span> <span   class="spack-highlighted">Installing</span> <span class="spack-green">netcdf-fortran-4.6.1-ntfunrmysxanqqu7sqfmf66zdkd2xemy</span> <span class="spack-highlighted">[17/19]</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/netcdf-fortran-4.6.1-ntfunrmysxanqqu7sqfmf66zdkd2xemy
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-indigo bold">\==></span> <span   class="spack-highlighted">Installing</span> <span class="spack-green">oasis3-mct-git.2023.11.09=2023.11.09-kok5n7hvm374eicnidcedxhgxmmytc2p</span> <span class="spack-highlighted">[18/19]</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/oasis3-mct-git.2023.11.09=2023.11.09-kok5n7hvm374eicnidcedxhgxmmytc2p
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-indigo bold">\==></span> <span   class="spack-highlighted">Installing</span> <span class="spack-green">access-test-git.2024.09.20=2024.09.20-hmy75yl26hexivgsw7zhlvbnjgst3gwc</span> <span class="spack-highlighted">[19/19]</span>
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/access-test-git.2024.09.20=2024.09.20-hmy75yl26hexivgsw7zhlvbnjgst3gwc
-    </terminal-line>
-    <terminal-line>
-        <span class="spack-indigo bold">\==></span> Updating view at /g/data/$PROJECT/$USER/spack/0.22/environments/test/.spack-env/view
+        <span class="spack-green">[+]</span> /g/data/$PROJECT/$USER/spack/0.22/release/linux-rocky8-x86_64/intel-2021.10.0/access-test-git.2025.04.000_2025.04.000-ih4cowpiz2kv6tnz4rkualxuly54tizr
     </terminal-line>
 </terminal-window>
 
@@ -312,7 +202,7 @@ spack find
         <span class="spack-indigo">\==></span> 1 root specs
     </terminal-line>
     <terminal-line>
-        <span class="spack-green"> [+] </span> access-test<span class="spack-cyan">@git.2024.09.20</span>
+        <span class="spack-green"> [+] </span> access-test<span class="spack-cyan">@git.2025.04.000=2025.04.000</span>
     </terminal-line>
     <terminal-line></terminal-line>
     <terminal-line>
@@ -322,22 +212,14 @@ spack find
         -- <span class="spack-pink">linux-rocky8-x86_64</span> / <span class="spack-green">intel@2021.10.0</span> ------------------------
     </terminal-line>
     <terminal-line class="ls-output-format">
-        <span class="spack-highlighted">access-test</span><span class="spack-cyan">@git.2024.09.20</span> 
-        diffutils<span class="spack-cyan">@3.10</span> 
-        libaec<span class="spack-cyan">@1.0.6</span> netcdf-fortran<span class="spack-cyan">@4.6.1</span> snappy<span class="spack-cyan">@1.1.10</span> 
-        bzip2<span class="spack-cyan">@1.0.8</span> 
-        glibc<span class="spack-cyan">@2.28</span> 
-        libiconv<span class="spack-cyan">@1.17</span> oasis3-mct<span class="spack-cyan">@git.2023.11.09=2023.11.09</span> zlib-ng<span class="spack-cyan">@2.1.6</span>
-        c-blosc<span class="spack-cyan">@1.21.5</span> 
-        gmake<span class="spack-cyan">@4.4.1</span> 
-        lz4<span class="spack-cyan">@1.9.4</span> 
-        openmpi@4.1.5 zstd<span class="spack-cyan">@1.5.6</span> 
+        <span class="spack-highlighted">access-test</span><span class="spack-cyan">@git.2025.04.000=2025.04.000</span> 
+        access-test-component<span class="spack-cyan">@main</span> 
         cmake<span class="spack-cyan">@3.24.2</span> 
-        hdf5<span class="spack-cyan">@1.14.3</span> 
-        netcdf-c<span class="spack-cyan">@4.9.2</span> 
-        pkgconf<span class="spack-cyan">@2.2.0</span>
+        glibc<span class="spack-cyan">@2.28</span> 
+        gmake<span class="spack-cyan">@4.4.1</span> 
+        openmpi@4.1.5<span class="spack-cyan">@1.5.6</span> 
     </terminal-line>
-    <terminal-line><span class="spack-indigo">\==></span> 19 installed packages</terminal-line>
+    <terminal-line><span class="spack-indigo">\==></span> 6 installed packages</terminal-line>
 </terminal-window>
 
 ### Cleanup


### PR DESCRIPTION
Fixes #846.

The fix is not strictly within this PR, but it was due to the changes implemented in [ACCESS-NRI/ACCESS-TEST #35](https://github.com/ACCESS-NRI/ACCESS-TEST/pull/35) (further details in [this issue](https://github.com/ACCESS-NRI/ACCESS-TEST/issues/28)).

This PR updates the terminal animations for the example `spack` commands.