### PR TITLE
Fixed errors with id anchors

### DIFF
--- a/docs/about/contact.md
+++ b/docs/about/contact.md
@@ -20,4 +20,6 @@ Join the [ACCESS-Hive Forum](https://forum.access-hive.org.au/) and find related
 
 :fontawesome-brands-linkedin: [ACCESS-NRI LinkedIn](https://www.linkedin.com/in/access-nri)
 
-[^1]: _"Contact" image source_: [Image by pch.vector](https://www.freepik.com/free-vector/contact-concept-landing-page_5155590.htm#page=5&query=contact%20cartoon&position=6&from_view=search&track=ais) on Freepik
+<custom-references>
+Introductory image by [pch.vector](https://www.freepik.com/free-vector/contact-concept-landing-page_5155590.htm#page=5&query=contact%20cartoon&position=6&from_view=search&track=ais) on Freepik
+</custom-references>

--- a/docs/about/contribute/index.md
+++ b/docs/about/contribute/index.md
@@ -38,5 +38,7 @@ Contributions are encouraged from any member of the community regarding any aspe
     </a>
 </div>
 
-[^1]: _"How to contribute" sample image source_: [Image by pch.vector](https://www.freepik.com/free-vector/team-crisis-managers-solving-businessman-problems-employees-with-lightbulb-unraveling-tangle-vector-illustration-teamwork-solution-management-concept_10613678.htm#query=teamwork%20cartoon&position=18&from_view=keyword&track=ais) on Freepik
-[^2]: _"Contribute to github?" sample image source_: [Image by vectorjuice](https://www.freepik.com/free-vector/business-idea-generation-plan-development-pensive-man-with-lightbulb-cartoon-character-technical-mindset-entrepreneurial-mind-brainstorming-process_11668582.htm#page=9&query=idea%20cartoon&position=30&from_view=search&track=ais) on Freepik
+<custom-references>
+Introductory image by [pch.vector](https://www.freepik.com/free-vector/team-crisis-managers-solving-businessman-problems-employees-with-lightbulb-unraveling-tangle-vector-illustration-teamwork-solution-management-concept_10613678.htm#query=teamwork%20cartoon&position=18&from_view=keyword&track=ais) on Freepik
+_Quick Contribution_ image by [vectorjuice](https://www.freepik.com/free-vector/business-idea-generation-plan-development-pensive-man-with-lightbulb-cartoon-character-technical-mindset-entrepreneurial-mind-brainstorming-process_11668582.htm#page=9&query=idea%20cartoon&position=30&from_view=search&track=ais) on Freepik
+</custom-references>

--- a/docs/models/run-a-model/create-a-prerelease.md
+++ b/docs/models/run-a-model/create-a-prerelease.md
@@ -183,16 +183,17 @@ There are three main _statuses_ for a deployment that can be identified by looki
   If a deployment is successful, it can be accessed on HPC systems.<br>
   ![Active deployment](/assets/create_a_prerelease/active_deployment.png){: style="max-width: 650px;" class="example-img" loading="lazy"}
   ![Inactive deployment](/assets/create_a_prerelease/inactive_deployment.png){: style="max-width: 650px;" class="example-img" loading="lazy"}
-  {: id="successful-deployment"}
+  {: #successful-deployment }
 
 - **In Progress**<br>
   The deployment is still ongoing. It will soon become [successful](#successful-deployment) or [fail](#failed-deployment).<br>
   ![In progress deployment](/assets/create_a_prerelease/in_progress_deployment.png){: style="max-width: 650px;" class="example-img" loading="lazy"}
-  {: id="in-progress-deployment"}
+  {: #in-progress-deployment }
 
 - **Failed**<br>
   The deployment failed and the CI/CD log can be viewed by clicking on [Show environments](https://github.com/ACCESS-NRI/ACCESS-OM2/pull/94#:~:text=Show%20environments) in the GitHub Environment diaglog box.<br>
   ![Failed deployment](/assets/create_a_prerelease/failed_deployment.png){: style="max-width: 650px;" class="example-img" loading="lazy"}
+  {: #failed-deployment }
 
 If we open a PR to the [ACCESS-OM2 deployment repository][om2 repo] with our `update_mom5_dev_build` branch as the *base*, we will get a [comment](https://github.com/ACCESS-NRI/ACCESS-OM2/pull/94#issuecomment-2594604585). Once deployed, the prerelease build can be accessed through the module `access-om2/pr94-1`:
 ![GitHub bot comment](/assets/create_a_prerelease/comment.png){: class="example-img"}

--- a/docs/models/run-a-model/run-access-esm.md
+++ b/docs/models/run-a-model/run-access-esm.md
@@ -307,7 +307,7 @@ Model components are separated into subdirectories within the output and restart
 
 ----------------------------------------------------------------------------------------
 
-## Edit {{ model }} configuration
+## Edit {{ model }} configuration {: #edit-{{ model.lower() }}-configuration }
 
 This section describes how to modify {{ model }} configuration.<br>
 The modifications discussed in this section can change the way {{ model }} is run by _payu_, or how its specific [model components] are configured and coupled together.

--- a/docs/models/run-a-model/run-access-ram.md
+++ b/docs/models/run-a-model/run-access-ram.md
@@ -705,7 +705,7 @@ To check the RNS suite logs, follow the steps listed in [Check suite logs](#chec
 
 All the RNS output files are available in the directory `/scratch/$PROJECT/$USER/cylc-run/<suite-ID>`. They are also symlinked in `~/cylc-run/<suite-ID>`.
 
-The RNS output data can be found in the directory `/scratch/$PROJECT/$USER/cycl-run/<suite-ID>/share/cycle`, grouped for each [cycle](#change-run-length-and-cycling-frequency).<br>
+The RNS output data can be found in the directory `/scratch/$PROJECT/$USER/cycl-run/<suite-ID>/share/cycle`, grouped for each [cycle](#change-run-length).<br>
 Within the `cycle` directory, outputs are divided into multiple nested subdirectories in the format `<nested_region_name>/<science_configuration>/<nest_name>`, with [`<nested_region_name>`](#change-the-nested-region-name) and `<nest_name>` referring to the respective configurable options. The `<science_configuration>` is usually `GAL9` or `RAL3.2`, depending on the [nest resolution]({{ model_configurations }}/#model-components).
 
 Each `<nest_name>` directory has the following subdirectories:


### PR DESCRIPTION
## Overview
This PR fixes the issues with missing id anchors in the documentation.
The missing anchors are listed from lines 379 to 385 of [this build log](https://github.com/ACCESS-NRI/access-hive.org.au/actions/runs/14584215362/job/40906750636#step:6:380).