### PR TITLE
Update COSIMA cookbook page with references from hh5 to xp65

### DIFF
--- a/docs/model_evaluation/evaluation_on_gadi/cosima.md
+++ b/docs/model_evaluation/evaluation_on_gadi/cosima.md
@@ -6,7 +6,7 @@
 ???+ warning "Support Level: Supported on <i>Gadi</i>, but not owned by ACCESS-NRI"
     <!-- Who develped the tool? -->
     The <i>COSIMA Cookbook</i> is developed and maintained by COSIMA. While ACCESS-NRI does not own the code, it actively supports the use of the recipes within the <i>COSIMA Cookbook</i> on <i>Gadi</i>. 
-    ACCESS-NRI provides access to the latest version of <i>COSIMA Cookbook</i> via the `hh5` `access-med` conda environment for Model Evaluation on Gadi.
+    ACCESS-NRI provides access to the latest version of <i>COSIMA Cookbook</i> via the `xp65` `conda/analysis3` conda environment for Model Evaluation on Gadi.
 
 The <i>COSIMA Cookbook</i> framework focuses on the <a href="/models/configurations/access-om">ACCESS-OM2</a> suite of models being developed and run by members of <a href="http://cosima.org.au/" target="_blank">COSIMA</a>. Nevertheless, this framework is suited to analysing any MOM5/MOM6 output as well as output from other models.
 
@@ -15,16 +15,16 @@ The <i>COSIMA Cookbook</i> framework focuses on the <a href="/models/configurati
 The easiest way to use the _COSIMA Cookbook_ is through the [Australian Research Environment (ARE)](https://are.nci.org.au)" on _Gadi_.<br>
 To be able to access _Gadi_ you need to have an NCI account. For more information, check how to [Set Up your NCI Account](/getting_started/set_up_nci_account).
 
-To use the <i>COSIMA Cookbook</i> that is pre-installed in the `conda/analysis3` environment of *hh5*, you need to <a href="https://my.nci.org.au/mancini/project/hh5" target="_blank">join NCI project *hh5*</a>.
+To use the <i>COSIMA Cookbook</i> that is pre-installed in the `conda/analysis3` environment of *xp65*, you need to <a href="https://my.nci.org.au/mancini/project/xp65" target="_blank">join NCI project *xp65*</a>.
 
 1. Login  via *ssh* to <i>Gadi</i> and clone the <a href="https://github.com/COSIMA/cosima-recipes" target="_blank"><i>cosima-recipes</i></a> repository to your local directory.  
 
 2. Find the recipes that you want to run and make sure you have access to the specific projects and their storage (e.g., project *ik11* to get access to */g/data/ik11*).
 
 3. Start an <a href="https://are.nci.org.au" target="_blank">ARE JupyterLab</a> session on NCI:  
-  <b>Storage</b>: `gdata/hh5` (add the specific storage you need for the recipe you want to run)
+  <b>Storage</b>: `gdata/xp65` (add the specific storage you need for the recipe you want to run)
   <br>
-  <b>Module directories</b>: `/g/data/hh5/public/modules`  
+  <b>Module directories</b>: `/g/data/xp65/public/modules`  
   <b>Modules</b>: `conda/analysis3`
   <br>
   If you are new to ARE, refer to instructions on [Getting Started with ARE](/getting_started/are).


### PR DESCRIPTION
## Description

Update COSIMA cookbook page. Changing where hh5 is referenced to xp65 for the updated conda environments.

## Checklist:

- [x] The new content is accessible and located in the appropriate section
- [x] My changes do not break navigation and do not generate new warnings
- [x] I have checked that the links are valid and point to the intended content
- [x] I have checked my code/text and corrected any misspellings
- [ ] ~I have chosen the correct tag for the level of [support provided](https://access-hive.org.au/#support)~
