### PR TITLE
how to run ACCESS-rOM3-panan documentation (take 2)

### DIFF
--- a/docs/models/run-a-model/run-access-rOM3-panan.md
+++ b/docs/models/run-a-model/run-access-rOM3-panan.md
@@ -1,0 +1,23 @@
+{% set model = "ACCESS-rOM3-panan" %}
+{% set github_configs = "https://github.com/ACCESS-NRI/access-om3-configs" %}
+{% set release_notes = "https://forum.access-hive.org.au/t/access-om2-release-information/1602/" %}
+[cosima]: https://cosima.org.au
+[PBS job]: https://opus.nci.org.au/display/Help/4.+PBS+Jobs
+[payu]: https://github.com/payu-org/payu
+[model components]: /models/configurations/access-om/#model-components
+[model configurations]: /models/configurations/access-om/#access-om2
+[gadi]: https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi#id-0.WelcometoGadi-Overview
+
+<div class="text-card-group" markdown>
+
+[:fontawesome-brands-github:{: class="twemoji icon-before-text"} {{ model }} configurations]({{github_configs}}){: class="text-card"}
+[:notepad_spiral:{: class="twemoji icon-before-text"} Release notes]({{release_notes}}){: class="text-card"}
+</div>
+
+# Run {{ model }}
+
+## About
+
+THIS is a DRAFT, suggesting looking at 
+
+run-access-om3.md in the origin/cbull/run-ACCESS-OM3 branch.

--- a/docs/models/run-a-model/run-access-rOM3-panan.md
+++ b/docs/models/run-a-model/run-access-rOM3-panan.md
@@ -8,11 +8,6 @@
 [model configurations]: /models/configurations/access-om/#access-om2
 [gadi]: https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi#id-0.WelcometoGadi-Overview
 
-<div class="text-card-group" markdown>
-
-[:fontawesome-brands-github:{: class="twemoji icon-before-text"} {{ model }} configurations]({{github_configs}}){: class="text-card"}
-[:notepad_spiral:{: class="twemoji icon-before-text"} Release notes]({{release_notes}}){: class="text-card"}
-</div>
 
 # Run {{ model }}
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ nav:
     - Run ACCESS-CM: models/run-a-model/run-access-cm.md
     - Run ACCESS-ESM: models/run-a-model/run-access-esm.md
     - Run ACCESS-OM: models/run-a-model/run-access-om.md
+    - Run run-ACCESS-rOM3-panan: models/run-a-model/run-ACCESS-rOM3-panan.md
     - Run ACCESS-rAM: models/run-a-model/run-access-ram.md
     - Modify and build an ACCESS model's source code: models/run-a-model/build_a_model.md
     - Create Prereleases and Releases for an ACCESS Model: models/run-a-model/create-a-prerelease.md


### PR DESCRIPTION
As part of this [discussion](https://github.com/ACCESS-NRI/access-om3-configs/issues/561), this is the start of making a fully supported ACCESS-rOM3-panan documentation. ping @claireyung @helenmacdonald @atteggiani @heidinett.

Here's some steps to edit this on a terminal:
```bash
git clone git@github.com:ACCESS-NRI/access-hive.org.au.git
cd [access-hive.org.au/](http://access-hive.org.au/)
git branch -vva
git checkout remotes/origin/cbull/run-ACCESS-rOM3-panan
git switch -c origin/cbull/run-ACCESS-rOM3-panan
#edit the new `run-access-rOM3-panan.md` file in `access-hive.org.au/docs/models/run-a-model`
#nb: could base it on run-access-om.md or `run-access-om3.md` in the `origin/cbull/run-ACCESS-OM3` branch
#make changes
git add run-access-rOM3-panan.md
git commit -m 'message'
git push --set-upstream origin cbull/run-ACCESS-rOM3-panan
```
A PR-preview will then appear in this draft PR. 

Could be useful to look at the accompanying [OM3 doc here](https://github.com/ACCESS-NRI/access-hive.org.au/pull/893).

Alternatively just edit `run-access-rOM3-panan.md` online here and use GitHub to commit.

NB: not looking for a review just yet!