### PR TITLE
spack.md: use a new bash shell environment

### DIFF
--- a/docs/getting_started/spack.md
+++ b/docs/getting_started/spack.md
@@ -52,7 +52,8 @@ For instructions on how to build an ACCESS model using _Spack_, refer to [Modify
 ## Enable Spack
 
 !!! warning
-    Use a new `bash` shell environment to ensure conflicting environment variables are avoided. Furthermore, this step needs to be carried out for any new login or new shell environment.
+    Use a bash shell environment when running Spack.
+    Use a new login and shell environment to ensure conflicting environment variables are avoided. Furthermore, this step needs to be carried out for any new login or new shell environment.
 
 ```
 cd /g/data/$PROJECT/$USER/spack/0.22

--- a/docs/getting_started/spack.md
+++ b/docs/getting_started/spack.md
@@ -52,7 +52,7 @@ For instructions on how to build an ACCESS model using _Spack_, refer to [Modify
 ## Enable Spack
 
 !!! warning
-    This step needs to be carried out for any new login or new shell environment.
+    Use a new `bash` shell environment to ensure conflicting environment variables are avoided. Furthermore, this step needs to be carried out for any new login or new shell environment.
 
 ```
 cd /g/data/$PROJECT/$USER/spack/0.22

--- a/docs/getting_started/spack.md
+++ b/docs/getting_started/spack.md
@@ -11,7 +11,19 @@ To use _Spack_, please familiarise yourself with the [Basic Usage instructions](
 We also recommend that you refer to the [Spack 101 Tutorial](https://spack-tutorial.readthedocs.io/en/latest/).
 
 ## Prerequisites
-These instructions are tailored specifically for _Gadi_. To use _Spack_ on _Gadi_, you must have an NCI account. For instructions on how to set up an account, refer to [Set Up your NCI Account](/getting_started/set_up_nci_account).
+- **NCI Account**<br> 
+    These instructions are tailored specifically for _Gadi_. To use _Spack_ on _Gadi_, you need to [Set Up your NCI Account](/getting_started/set_up_nci_account).
+- **_Bash_ shell**<br>
+    The following instructions must be run in a _Bash_ shell, which is the default shell on _Gadi_.
+    To check if you are using _Bash_, run:
+    ```
+    echo "$BASH_VERSION"
+    ```
+    If you see an output (i.e. the _Bash_ version), you are already in a Bash shell. If there is no output, start a _Bash_ shell by running:
+    ```
+    bash
+    ```
+{: #bash_shell }
 
 ## Set up Spack on Gadi
 
@@ -52,8 +64,8 @@ For instructions on how to build an ACCESS model using _Spack_, refer to [Modify
 ## Enable Spack
 
 !!! warning
-    Use a bash shell environment when running Spack.
-    Use a new login and shell environment to ensure conflicting environment variables are avoided. Furthermore, this step needs to be carried out for any new login or new shell environment.
+    For this step, it is recommended to use a new login [_Bash_ shell environment](#bash_shell) to avoid conflicting environment variables. 
+    Additionally, this step must be repeated for every new login or new shell session.
 
 ```
 cd /g/data/$PROJECT/$USER/spack/0.22

--- a/docs/getting_started/spack.md
+++ b/docs/getting_started/spack.md
@@ -19,7 +19,7 @@ We also recommend that you refer to the [Spack 101 Tutorial](https://spack-tutor
     ```
     echo "$BASH_VERSION"
     ```
-    If you see an output (i.e. the _Bash_ version), you are already in a Bash shell. If there is no output, start a _Bash_ shell by running:
+    If you see output (i.e. the _Bash_ version), you are already in a Bash shell. If there is no output, start a _Bash_ shell by running:
     ```
     bash
     ```

--- a/docs/models/run-a-model/build_a_model.md
+++ b/docs/models/run-a-model/build_a_model.md
@@ -45,7 +45,8 @@ cd /g/data/$PROJECT/$USER/spack/0.22
 ## Enable spack
 
 !!! warning
-    This step needs to be carried out for any new login or new shell environment.
+    For this step, it is recommended to use a new login _Bash_ shell environment to avoid conflicting environment variables.
+    Additionally, this step must be repeated for every new login or new shell session.
 
 To add the `spack` command to your shell, as well as other settings, run:
 ```


### PR DESCRIPTION
Users should start a new bash shell environment before using Spack. Be explicit in our instructions.