### PR TITLE
Bump mkdocs-bibtex

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 mkdocs-material==9.6.12
 mkdocs-git-revision-date-localized-plugin==1.4.5
 mkdocs-macros-plugin==1.3.7
-mkdocs-bibtex==4.2.5
+mkdocs-bibtex==4.4.0
 git+https://github.com/rbeucher/mkdocs_events_plugin.git
 git+https://github.com/ACCESS-NRI/mkdocs_resolve_absolute_urls_plugin.git@1.1.0


### PR DESCRIPTION
Bumped `mkdocs-bibtex` extension to v4.4.0 (#971)